### PR TITLE
avoid overflow of printing blockinfo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ function consoleObjCallbackLog(error, result, name) {
     if(name) {
       console.log(name, 'reply:')
     }
-    console.log(JSON.stringify(result, null, 4))
+    //console.log(JSON.stringify(result, null, 4))
   }
 }
 


### PR DESCRIPTION
`console.log(JSON.stringify(result, null, 4))` will quickly overflow the browsers console during the testing with public testnet with contracts, which will bring inconvenience to developers.

Especially when it comes to `getTableRows()`, printing huge amount of texts to the console quickly,  bring difficulty to filter out text and make the browsers stuck.