### PR TITLE
expose current version number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,11 @@ const AbiCache = require('./abi-cache')
 const writeApiGen = require('./write-api')
 const assert = require('assert')
 const format = require('./format')
-const Eos = {}
+
+const pkg = require('../package.json')
+const Eos = {
+  version: pkg.version
+}
 
 module.exports = Eos
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,6 +5,12 @@ const Eos = require('.')
 const {ecc} = Eos.modules
 const {Keystore} = require('eosjs-keygen')
 
+describe('version', () => {
+  it('exposes a version number', () => {
+    assert.ok(Eos.version)
+  })
+})
+
 // even transactions that don't broadcast require Api lookups
 //  no testnet yet, avoid breaking travis-ci
 if(process.env['NODE_ENV'] === 'development') {


### PR DESCRIPTION
this makes it easy for library users to check the current version,
e.g. for debugging and adding the version number to stack traces.

tested for node and the browser:

![screen shot 2018-01-22 at 15 59 56](https://user-images.githubusercontent.com/298166/35227072-59bb75b8-ff8d-11e7-90e0-296df84447d8.png)
