### PR TITLE
Dawn 2x support notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 dist
 lib
 .nyc_output
+.idea

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/EOSIO/eosjs.svg?branch=master)](https://travis-ci.org/EOSIO/eosjs)
 [![NPM](https://img.shields.io/npm/v/eosjs.svg)](https://www.npmjs.org/package/eosjs)
 
-### The current release of eos-js is built for the last stable eos build Dawn 2.x
+### The current release of eosjs is built for the last stable eos build Dawn 2.x
 You can find the current stable branch of eos here: https://github.com/EOSIO/eos/tree/dawn-2.x
 
 We are actively working on building a version compatible with Dawn 3.x (current master): https://github.com/EOSIO/eosjs/issues/25

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 [![Build Status](https://travis-ci.org/EOSIO/eosjs.svg?branch=master)](https://travis-ci.org/EOSIO/eosjs)
 [![NPM](https://img.shields.io/npm/v/eosjs.svg)](https://www.npmjs.org/package/eosjs)
 
+### The current release of eos-js is built for the last stable eos build Dawn 2.x
+You can find the current stable branch of eos here: https://github.com/EOSIO/eos/tree/dawn-2.x
+
+We are actively working on building a version compatible with Dawn 3.x (current master): https://github.com/EOSIO/eosjs/issues/25
+
 # Eosjs
 
 General purpose library for the EOS blockchain.


### PR DESCRIPTION
@jcalfee this PR accomplishes 2 things
1. Intellij project directories will be ignored
2. Adds notice to the read me that eosjs currently supports dawn 2.x and educates users where they can find the current stable eos branch to work with while we build out 3.x support