### PR TITLE
Add docker config and test script to run the integration tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM eosio/eos:latest
+
+COPY config.ini genesis.json /
+

--- a/docker/config.ini
+++ b/docker/config.ini
@@ -1,0 +1,95 @@
+# Track only transactions whose scopes involve the listed accounts. Default is to track all transactions.
+# filter_on_accounts =
+
+# Limits the maximum time (in milliseconds) processing a single get_transactions call.
+get-transactions-time-limit = 3
+
+# File to read Genesis State from
+ genesis-json = ./genesis.json
+
+# override the initial timestamp in the Genesis State file
+# genesis-timestamp =
+
+# the location of the block log (absolute path or relative to application data dir)
+block-log-dir = "blocks"
+
+# Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
+# checkpoint =
+
+# the location of the chain shared memory files (absolute path or relative to application data dir)
+shared-file-dir = "blockchain"
+
+# Minimum size MB of database shared memory file
+shared-file-size = 8192
+
+# The local IP and port to listen for incoming http connections.
+http-server-address = 0.0.0.0:8888
+
+# Specify the Access-Control-Allow-Origin to be returned on each request.
+# access-control-allow-origin =
+
+# Specify the Access-Control-Allow-Headers to be returned on each request.
+# access-control-allow-headers =
+
+# Specify if Access-Control-Allow-Credentials: true should be returned on each request.
+access-control-allow-credentials = false
+
+# The actual host:port used to listen for incoming p2p connections.
+p2p-listen-endpoint = 0.0.0.0:9876
+
+# An externally accessible host:port for identifying this node. Defaults to p2p-listen-endpoint.
+# p2p-server-address =
+
+# The public endpoint of a peer node to connect to. Use multiple p2p-peer-address options as needed to compose a network.
+# p2p-peer-address =
+
+# The name supplied to identify this node amongst the peers.
+agent-name = "EOS Test Agent"
+
+# True to always send full blocks, false to send block summaries
+send-whole-blocks = 1
+
+# Can be 'any' or 'producers' or 'specified' or 'none'. If 'specified', peer-key must be specified at least once. If only 'producers', peer-key is not required. 'producers' and 'specified' may be combined.
+allowed-connection = any
+
+# Optional public key of peer allowed to connect.  May be used multiple times.
+# peer-key =
+
+# Tuple of [PublicKey, WIF private key] (may specify multiple times)
+# peer-private-key =
+ # Log level: one of 'all', 'debug', 'info', 'warn', 'error', or 'off'
+log-level-net-plugin = info
+
+# Maximum number of clients from which connections are accepted, use 0 for no limit
+max-clients = 25
+
+# number of seconds to wait before cleaning up dead connections
+connection-cleanup-period = 30
+
+# True to require exact match of peer network version.
+network-version-match = 0
+
+# Enable block production, even if the chain is stale.
+enable-stale-production = true
+
+# Percent of producers (0-99) that must be participating in order to produce blocks
+required-participation = false
+
+# ID of producer controlled by this node (e.g. inita; may specify multiple times)
+# producer-name =
+
+# Tuple of [public key, WIF private key] (may specify multiple times)
+private-key = ["EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]
+
+# Plugin(s) to enable, may be specified multiple times
+# plugin =
+# Plugin(s) to enable, may be specified multiple times
+plugin = eosio::producer_plugin
+plugin = eosio::chain_api_plugin
+plugin = eosio::wallet_api_plugin
+plugin = eosio::account_history_api_plugin
+plugin = eosio::http_plugin
+# plugin = eosio::mongo_db_plugin
+
+# Enable block production with the testnet producers
+producer-name = eosio

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+  nodeos:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: eos
+    command: /opt/eosio/bin/start_nodeos.sh
+    ports:
+      - 8888:8888
+      - 9876:9876
+    expose:
+      - "8888"
+    volumes:
+      - nodeos-data-volume:/opt/eosio/bin/data-dir
+
+  walletd:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: eos
+    command: /opt/eosio/bin/eosiowd
+    links:
+      - nodeos
+    volumes:
+      - walletd-data-volume:/opt/eosio/bin/data-dir
+
+volumes:
+  nodeos-data-volume:
+  walletd-data-volume:

--- a/docker/genesis.json
+++ b/docker/genesis.json
@@ -1,0 +1,16 @@
+{
+    "initial_key": "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+    "initial_timestamp": "2017-03-30T12:00:00",
+    "initial_parameters": {
+      "maintenance_interval": 86400,
+      "maintenance_skip_slots": 3,
+      "maximum_transaction_size": 2048,
+      "maximum_block_size": 2048000000,
+      "maximum_time_until_expiration": 86400,
+      "maximum_producer_count": 1001
+    },
+    "immutable_parameters": {
+      "min_producer_count": 21
+    },
+    "initial_chain_id": "0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/env bash
+CLEOS='docker-compose exec walletd /opt/eosio/bin/cleos -H nodeos'
+
+# Reset the volumes
+docker-compose down
+
+# pull the latest image
+# docker pull eosio/eos
+
+# Start the server for testing 
+docker-compose up -d
+
+$CLEOS wallet create
+$CLEOS wallet import 5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
+
+# create accounts
+$CLEOS create account eosio currency EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+$CLEOS create account eosio exchange EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+$CLEOS create account eosio inita EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+$CLEOS create account eosio initb EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+$CLEOS create account eosio initc EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
+
+# publish smart contracts
+$CLEOS set contract currency contracts/currency/currency.wast contracts/currency/currency.abi
+$CLEOS set contract exchange contracts/exchange/exchange.wast contracts/exchange/exchange.abi
+$CLEOS set contract eosio contracts/eosio.system/eosio.system.wast contracts/eosio.system/eosio.system.abi
+
+# issue new tokens
+$CLEOS push action eosio issue '{"to":"eosio", "quantity": "1000000000.0000 EOS", "memo": ""}' -p eosio@active
+$CLEOS push action currency create '{"issuer":"currency", "maximum_supply": "1000000000.0000 CUR", "can_freeze": 1, "can_recall": 1, "can_whitelist": 1}' -p currency@active
+
+$CLEOS push action eosio issue '{"to":"inita", "quantity": "1000000000.0000 EOS", "memo": ""}' -p eosio@active
+$CLEOS push action eosio issue '{"to":"initb", "quantity": "1000000000.0000 EOS", "memo": ""}' -p eosio@active
+$CLEOS push action eosio issue '{"to":"initc", "quantity": "1000000000.0000 EOS", "memo": ""}' -p eosio@active
+
+cd ..
+npm install
+NODE_ENV=development CURRENCY_ABI= npm run test 


### PR DESCRIPTION
I added this code in order to simplify running the integration tests.
For now it is in a docker folder, but let me know if you want it organized in another way.
We should be able to use this to run the integration tests in either Jenkins or Trevis.

Docker build on master of EOS is broken, to test this, there need to have this fix: 
https://github.com/EOSIO/eos/pull/1717
