### PR TITLE
Importing ecc

### DIFF
--- a/src/structs.js
+++ b/src/structs.js
@@ -1,4 +1,4 @@
-const {PublicKey} = require('eosjs-ecc')
+const {ecc,PublicKey} = require('eosjs-ecc')
 const json = require('eosjs-json')
 const Fcbuffer = require('fcbuffer')
 const ByteBuffer = require('bytebuffer')

--- a/src/structs.js
+++ b/src/structs.js
@@ -1,4 +1,4 @@
-const {ecc,PublicKey} = require('eosjs-ecc')
+const {Signature,PublicKey} = require('eosjs-ecc')
 const json = require('eosjs-json')
 const Fcbuffer = require('fcbuffer')
 const ByteBuffer = require('bytebuffer')
@@ -318,19 +318,19 @@ const Signature = (validation, baseTypes, customTypes) => {
     fromByteBuffer (b) {
       console.log(1);
       const signatureBuffer = signatureType.fromByteBuffer(b)
-      const signature = ecc.Signature.from(signatureBuffer)
+      const signature = Signature.from(signatureBuffer)
       return signature.toString()
     },
 
     appendByteBuffer (b, value) {
       console.log(2);
-      const signature = ecc.Signature.from(value)
+      const signature = Signature.from(value)
       signatureType.appendByteBuffer(b, signature.toBuffer())
     },
 
     fromObject (value) {
       console.log(3);
-      const signature = ecc.Signature.from(value)
+      const signature = Signature.from(value)
       return signature.toString()
     },
 
@@ -339,7 +339,7 @@ const Signature = (validation, baseTypes, customTypes) => {
       if (validation.defaults && value == null) {
         return 'SIGnature..'
       }
-      const signature = ecc.Signature.from(value)
+      const signature = Signature.from(value)
       return signature.toString()
     }
   }


### PR DESCRIPTION
Signatures could not be rebuilt ( L:321, L:328, L:333, L:342 ) due to ecc not being imported and returning undefined.

```
ReferenceError: ecc is not defined user.sig action.data transaction.actions
    at Object.fromObject (D:\Work\Websites\scatter-hackathon\node_modules\eosjs\lib\structs.js:414:23)
```

(Note, this fix is untested on the library itself, only within the transpiled code)
```
var _require = require('eosjs-ecc'),
    ecc = _require,
    PublicKey = _require.PublicKey;
```