### PR TITLE
Optional Chain ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,11 +76,8 @@ function createEos(config) {
   config.assetCache = AssetCache(network)
   config.abiCache = AbiCache(network, config)
 
-  if(!config.chainId) {
-    config.chainId = 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f'
-  }
-
-  checkChainId(network, config.chainId)
+  if(config.hasOwnPropety('chainId'))
+     checkChainId(network, config.chainId)
 
   if(config.mockTransactions != null) {
     if(typeof config.mockTransactions === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ function createEos(config) {
   config.assetCache = AssetCache(network)
   config.abiCache = AbiCache(network, config)
 
-  if(config.hasOwnPropety('chainId'))
+  if(config.hasOwnProperty('chainId'))
      checkChainId(network, config.chainId)
 
   if(config.mockTransactions != null) {


### PR DESCRIPTION
This is an untested flow suggestion but should not cause conflicts.
An error will still be thrown by the [write-api](https://github.com/EOSIO/eosjs/blob/4-binaryen/src/write-api.js#L14) in the case where an app is trying to push transactions with an Eos instance that did not include a `chainId`, but will allow for __read only__ mode.