### PR TITLE
Option to not check chainId. Useful for offline wallets.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@ const pkg = require('../package.json')
 const configDefaults = {
   broadcast: true,
   debug: false,
-  sign: true
+  sign: true,
+  checkChainId: true
 }
 
 const Eos = (config = {}) => createEos(
@@ -80,7 +81,10 @@ function createEos(config) {
     config.chainId = 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f'
   }
 
-  checkChainId(network, config.chainId)
+  // for offline use
+  if(config.checkChainId) {
+      checkChainId(network, config.chainId)
+  }
 
   if(config.mockTransactions != null) {
     if(typeof config.mockTransactions === 'string') {


### PR DESCRIPTION
Additional check of `chainId` was introduced in https://github.com/EOSIO/eosjs/issues/131. While such a check is very useful in most cases, it is no desired while generating transaction offline.

Developers should be able to disable this check, if they know that `chainId` provided by them is correct.