### PR TITLE
format: include on instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,10 @@ function createEos(config) {
     toBuffer
   }})
 
+  Object.assign(eos, {modules: {
+    format
+  }})
+
   if(!config.signProvider) {
     config.signProvider = defaultSignProvider(eos, config)
   }


### PR DESCRIPTION
Since v15 `UDecimalPad` is used heavily when developing an
application. By making the formatter available on the instance we
can conveniently use them in functions which receive an eos
instance by dependency injection.