### PR TITLE
added `unalias cleos`

### DIFF
--- a/docker/dockrc.sh
+++ b/docker/dockrc.sh
@@ -5,6 +5,8 @@
 export owner_pubkey=EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
 export active_pubkey=EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
 
+unalias cleos
+
 function cleos() {
   docker-compose exec keosd cleos -u http://nodeosd:8888 --wallet-url http://localhost:8900 "$@"
 }


### PR DESCRIPTION
added `unalias cleos` for people who followed the instructions from the eosio dev docs and got an Error: No such container: eosio
https://developers.eos.io/eosio-nodeos/docs/docker-quickstart