### PR TITLE
Fix to prevent returning wrong authority string if this is a non-EOS prefix (e.g. TLOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ eos = Eos({httpEndpoint, chainId, keyProvider})
 // Cold-storage
 eos = Eos({httpEndpoint: null, chainId, keyProvider})
 
+// Add support for non-EOS public key prefixes, such as TLOS, etc
+eos = Eos({keyPrefix:'TLOS'})
+
 // Read-only instance when 'eosjs' is already a dependency
 eos = Eos.modules.api({/*config*/})
 

--- a/src/structs.js
+++ b/src/structs.js
@@ -157,7 +157,7 @@ const PublicKeyEcc = (validation) => {
       const bcopy = b.copy(b.offset, b.offset + 33)
       b.skip(33)
       const pubbuf = Buffer.from(bcopy.toBinary(), 'binary')
-      // fix to prevent returning wrong authority string if this is a non-EOS prefix
+      // fix to prevent failure for non-EOS prefixes
       const keyPrefix = validation.keyPrefix ? validation.keyPrefix : 'EOS'
       return PublicKey.fromBuffer(pubbuf).toString(keyPrefix)
     },
@@ -166,7 +166,7 @@ const PublicKeyEcc = (validation) => {
       // if(validation.debug) {
       //   console.error(`${value}`, 'PublicKeyType.appendByteBuffer')
       // }
-      // fix to prevent returning wrong authority string if this is a non-EOS prefix
+      // fix to prevent failure for non-EOS prefixes
       const keyPrefix = validation.keyPrefix ? validation.keyPrefix : 'EOS'
       const buf = PublicKey.fromStringOrThrow(value,keyPrefix).toBuffer()
       b.append(buf.toString('binary'), 'binary')

--- a/src/structs.js
+++ b/src/structs.js
@@ -470,12 +470,12 @@ const SignatureType = (validation, baseTypes) => {
   }
 }
 
-const authorityOverride = validation => ({
+const authorityOverride = config => ({
   /** shorthand `EOS6MRyAj..` */
   'authority.fromObject': (value) => {
     // fix to prevent returning wrong authority string if this is a non-EOS prefix
-    const keyPrefix = validation.keyPrefix ? validation.keyPrefix : 'EOS';
-    if(PublicKey.fromString(value, validation.keyPrefix)) {
+    const keyPrefix = config.keyPrefix ? config.keyPrefix : 'EOS';
+    if(PublicKey.fromString(value, keyPrefix)) {
       return {
         threshold: 1,
         keys: [{key: value, weight: 1}]

--- a/src/structs.test.js
+++ b/src/structs.test.js
@@ -22,6 +22,21 @@ describe('shorthand', () => {
     )
   })
 
+  it('authority - diff prefix', async () => {
+    const eos = Eos({keyPrefix:'TLOS'})
+    const eosio = await eos.contract('eosio')
+    const {authority} = eosio.fc.structs
+
+    const pubkey = 'TLOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
+    const auth = {threshold: 1, keys: [{key: pubkey, weight: 1}]}
+
+    assert.deepEqual(authority.fromObject(pubkey), auth)
+    assert.deepEqual(
+      authority.fromObject(auth),
+      Object.assign({}, auth, {accounts: [], waits: []})
+    )
+  })
+
   it('PublicKey sorting', async () => {
     const eos = Eos()
     const eosio = await eos.contract('eosio')
@@ -51,6 +66,15 @@ describe('shorthand', () => {
     const {structs, types} = eos.fc
     const PublicKeyType = types.public_key()
     const pubkey = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
+    // 02c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf
+    assertSerializer(PublicKeyType, pubkey)
+  })
+
+  it('public_key - diff prefix', () => {
+    const eos = Eos({keyPrefix:'TLOS'})
+    const {structs, types} = eos.fc
+    const PublicKeyType = types.public_key()
+    const pubkey = 'TLOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
     // 02c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf
     assertSerializer(PublicKeyType, pubkey)
   })


### PR DESCRIPTION
Please consider merging this fix to prevent returning wrong authority string if this is a non-EOS prefix. Similar patches were merged and pushed to npm for related issues in eosjs-ecc, as confirmed in closed PRs https://github.com/EOSIO/eosjs-ecc/pull/30 and https://github.com/EOSIO/eosjs-ecc/pull/32

Can we get this merged and pushed to npm as soon as possible?