### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/src/structs.js
+++ b/src/structs.js
@@ -571,7 +571,7 @@ const actionDataOverride = (structLookup, forceActionDataHex) => ({
       b.append(b2.copy(0, b2.offset), 'binary')
     } else {
       // console.log(`Unknown Action.name ${object.name}`)
-      const data = typeof object.data === 'string' ? new Buffer(object.data, 'hex') : object.data
+      const data = typeof object.data === 'string' ? Buffer.from(object.data, 'hex') : object.data
       if(!Buffer.isBuffer(data)) {
         throw new TypeError(`Unknown struct '${object.name}' for contract '${object.account}', locate this struct or provide serialized action.data`)
       }
@@ -587,7 +587,7 @@ const actionDataOverride = (structLookup, forceActionDataHex) => ({
       if(typeof data === 'object') {
         result.data = ser.fromObject(data) // resolve shorthand
       } else if(typeof data === 'string') {
-        const buf = new Buffer(data, 'hex')
+        const buf = Buffer.from(data, 'hex')
         result.data = Fcbuffer.fromBuffer(ser, buf)
       } else {
         throw new TypeError('Expecting hex string or object in action.data')

--- a/src/write-api.js
+++ b/src/write-api.js
@@ -471,8 +471,8 @@ function WriteApi(Network, network, config, Transaction) {
 
       let sigs = []
       if(options.sign){
-        const chainIdBuf = new Buffer(config.chainId, 'hex')
-        const packedContextFreeData = new Buffer(new Uint8Array(32)) // TODO
+        const chainIdBuf = Buffer.from(config.chainId, 'hex')
+        const packedContextFreeData = Buffer.from(new Uint8Array(32)) // TODO
         const signBuf = Buffer.concat([chainIdBuf, buf, packedContextFreeData])
 
         sigs = config.signProvider({transaction: tr, buf: signBuf, sign,


### PR DESCRIPTION
This PR replaces all new Buffer which is deprecated and unsafe with Buffer.from
We should not use deprecated/unsafe Buffer constructor.

The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe