### PR TITLE
Use triple equals instead of double equals

### DIFF
--- a/src/abi-cache.js
+++ b/src/abi-cache.js
@@ -23,11 +23,11 @@ function AbiCache(network, config) {
   function abiAsync(account, force = true) {
     assert.equal(typeof account, 'string', 'account string required')
 
-    if(force == false && cache[account] != null) {
+    if(force === false && cache[account] !== null) {
       return Promise.resolve(cache[account])
     }
 
-    if(network == null) {
+    if(network === null) {
       const abi = cache[account]
       assert(abi, `Missing ABI for account: ${account}, provide httpEndpoint or add to abiCache`)
       return Promise.resolve(abi)
@@ -58,7 +58,7 @@ function AbiCache(network, config) {
       return cache[account] = Object.assign({abi, schema: fcSchema}, structs)
     }
     const c = cache[account]
-    if(c == null) {
+    if(c === null) {
       throw new Error(`Abi '${account}' is not cached`)
     }
     return c

--- a/src/format.js
+++ b/src/format.js
@@ -158,7 +158,7 @@ function decodeName(value, littleEndian = true) {
   @return {string} value
 */
 function DecimalString(value) {
-  assert(value != null, 'value is required')
+  assert(value !== null, 'value is required')
   value = value === 'object' && value.toString ? value.toString() : String(value)
 
   const neg = /^-/.test(value)
@@ -203,7 +203,7 @@ function DecimalString(value) {
 */
 function DecimalPad(num, precision) {
   const value = DecimalString(num)
-  if(precision == null) {
+  if(precision === null) {
     return value
   }
 
@@ -238,14 +238,14 @@ function DecimalImply(value, precision) {
   @return {number} 1.0000
 */
 function DecimalUnimply(value, precision) {
-  assert(value != null, 'value is required')
+  assert(value !== null, 'value is required')
   value = value === 'object' && value.toString ? value.toString() : String(value)
   const neg = /^-/.test(value)
   if(neg) {
     value = value.substring(1)
   }
   assert(/^\d+$/.test(value), `invalid whole number ${value}`)
-  assert(precision != null, 'precision required')
+  assert(precision !== null, 'precision required')
   assert(precision >= 0 && precision <= 18, `Precision should be 18 characters or less`)
 
   // Ensure minimum length
@@ -264,13 +264,13 @@ function DecimalUnimply(value, precision) {
 function printAsset({amount, precision, symbol, contract}) {
   assert.equal(typeof symbol, 'string', 'symbol is a required string')
 
-  if(amount != null && precision != null) {
+  if(amount !== null && precision !== null) {
     amount = DecimalPad(amount, precision)
   }
 
-  const join = (e1, e2) => e1 == null ? '' : e2 == null ? '' : e1 + e2
+  const join = (e1, e2) => e1 === null ? '' : e2 === null ? '' : e1 + e2
 
-  if(amount != null) {
+  if(amount !== null) {
     // the amount contains the precision
     return join(amount, ' ') + symbol + join('@', contract)
   }
@@ -295,7 +295,7 @@ function parseAsset(str) {
   const precisionMatch = str.match(/(^| )([0-9]+),([A-Z]+)(@|$)/)
   const precisionSymbol = precisionMatch ? Number(precisionMatch[2]) : null
   const precisionAmount = amount ? (amount.split('.')[1] || '').length : null
-  const precision = precisionSymbol != null ? precisionSymbol : precisionAmount
+  const precision = precisionSymbol !== null ? precisionSymbol : precisionAmount
 
   const symbolMatch = str.match(/(^| |,)([A-Z]+)(@|$)/)
   const symbol = symbolMatch ? symbolMatch[2] : null
@@ -307,13 +307,13 @@ function parseAsset(str) {
 
   assert.equal(str, check,  `Invalid asset string: ${str} !== ${check}`)
 
-  if(precision != null) {
+  if(precision !== null) {
     assert(precision >= 0 && precision <= 18, `Precision should be 18 characters or less`)
   }
-  if(symbol != null) {
+  if(symbol !== null) {
     assert(symbol.length <= 7, `Asset symbol is 7 characters or less`)
   }
-  if(contract != null) {
+  if(contract !== null) {
     assert(contract.length <= 12, `Contract is 12 characters or less`)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ Object.assign(
 )
 
 function createEos(config) {
-  const network = config.httpEndpoint != null ? EosApi(config) : null
+  const network = config.httpEndpoint !== null ? EosApi(config) : null
   config.network = network
 
   const abis = []
@@ -88,7 +88,7 @@ function createEos(config) {
     checkChainId(network, config.chainId, config.logger)
   }
 
-  if(config.mockTransactions != null) {
+  if(config.mockTransactions !== null) {
     if(typeof config.mockTransactions === 'string') {
       const mock = config.mockTransactions
       config.mockTransactions = () => mock
@@ -233,7 +233,7 @@ const defaultSignProvider = (eos, config) => async function({
   }
 
   // offline signing assumes all keys provided need to sign
-  if(config.httpEndpoint == null) {
+  if(config.httpEndpoint === null) {
     const sigs = []
     for(const key of keys) {
       sigs.push(sign(buf, key.private))
@@ -245,8 +245,8 @@ const defaultSignProvider = (eos, config) => async function({
 
   // keys are either public or private keys
   for(const key of keys) {
-    const isPrivate = key.private != null
-    const isPublic = key.public != null
+    const isPrivate = key.private !== null
+    const isPublic = key.public !== null
 
     if(isPrivate) {
       keyMap.set(ecc.privateToPublic(key.private), key.private)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -437,7 +437,7 @@ describe('transactions', () => {
           return token.transfer('initb', 'inita', '1.0000 SYS', '')
             .then(tr => {assert.equal(1, tr.transaction.transaction.actions.length)})
         })
-    }).then(r => {assert(r == undefined)})
+    }).then(r => {assert(r === undefined)})
   })
 
   it('action to contract atomic', async function() {
@@ -445,8 +445,8 @@ describe('transactions', () => {
     const eos = Eos({signProvider})
 
     const trTest = eosio_token => {
-      assert(eosio_token.transfer('inita', 'initb', amt + '.0000 SYS', '') == null)
-      assert(eosio_token.transfer('initb', 'inita', (amt++) + '.0000 SYS', '') == null)
+      assert(eosio_token.transfer('inita', 'initb', amt + '.0000 SYS', '') === null)
+      assert(eosio_token.transfer('initb', 'inita', (amt++) + '.0000 SYS', '') === null)
     }
 
     const assertTr = tr =>{
@@ -474,8 +474,8 @@ describe('transactions', () => {
   it('multi-action transaction (broadcast)', () => {
     const eos = Eos({signProvider})
     return eos.transaction(tr => {
-      assert(tr.transfer('inita', 'initb', '1.0000 SYS', '') == null)
-      assert(tr.transfer({from: 'inita', to: 'initc', quantity: '1.0000 SYS', memo: ''}) == null)
+      assert(tr.transfer('inita', 'initb', '1.0000 SYS', '') === null)
+      assert(tr.transfer({from: 'inita', to: 'initc', quantity: '1.0000 SYS', memo: ''}) === null)
     }).then(tr => {
       assert.equal(2, tr.transaction.transaction.actions.length)
     })

--- a/src/structs.js
+++ b/src/structs.js
@@ -20,7 +20,7 @@ module.exports = (config = {}, extendedSchema) => {
     for(const action of cache.abi.actions) {
       if(action.name === lookupName) {
         const struct = cache.structs[action.type]
-        if(struct != null) {
+        if(struct !== null) {
           return struct
         }
       }
@@ -28,7 +28,7 @@ module.exports = (config = {}, extendedSchema) => {
 
     // Lookup struct by "type"
     const struct = cache.structs[lookupName]
-    if(struct != null) {
+    if(struct !== null) {
       return struct
     }
 
@@ -38,7 +38,7 @@ module.exports = (config = {}, extendedSchema) => {
   // If nodeos does not have an ABI setup for a certain action.type, it will throw
   // an error: `Invalid cast from object_type to string` .. forceActionDataHex
   // may be used to until native ABI is added or fixed.
-  const forceActionDataHex = config.forceActionDataHex != null ?
+  const forceActionDataHex = config.forceActionDataHex !== null ?
     config.forceActionDataHex : true
 
   const override = Object.assign({},
@@ -108,7 +108,7 @@ const Name = (validation) => {
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return ''
       }
       return value
@@ -173,7 +173,7 @@ const PublicKeyEcc = (validation) => {
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         const keyPrefix = validation.keyPrefix ? validation.keyPrefix : 'EOS'
         return keyPrefix + '6MRy..'
       }
@@ -198,7 +198,7 @@ const Symbol = validation => {
 
       let symbol = ''
       for(const code of bin)  {
-        if(code == '\0') {
+        if(code === '\0') {
           break
         }
         symbol += code
@@ -208,15 +208,15 @@ const Symbol = validation => {
 
     appendByteBuffer (b, value) {
       const {symbol, precision} = parseAsset(value)
-      assert(precision != null, `Precision unknown for symbol: ${value}`)
+      assert(precision !== null, `Precision unknown for symbol: ${value}`)
       const pad = '\0'.repeat(7 - symbol.length)
       b.append(String.fromCharCode(precision) + symbol + pad)
     },
 
     fromObject (value) {
-      assert(value != null, `Symbol is required: ` + value)
+      assert(value !== null, `Symbol is required: ` + value)
       const {symbol, precision} = parseAsset(value)
-      if(precision == null) {
+      if(precision === null) {
         return symbol
       } else {
         // Internal object, this can have the precision prefix
@@ -225,7 +225,7 @@ const Symbol = validation => {
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return 'SYS'
       }
       // symbol only (without precision prefix)
@@ -245,7 +245,7 @@ const SymbolCode = validation => {
 
       let symbol = ''
       for(const code of bin)  {
-        if(code == '\0') {
+        if(code === '\0') {
           break
         }
         symbol += code
@@ -260,13 +260,13 @@ const SymbolCode = validation => {
     },
 
     fromObject (value) {
-      assert(value != null, `Symbol is required: ` + value)
+      assert(value !== null, `Symbol is required: ` + value)
       const {symbol} = parseAsset(value)
       return symbol
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return 'SYS'
       }
       return parseAsset(value).symbol
@@ -294,7 +294,7 @@ const ExtendedSymbol = (validation, baseTypes, customTypes) => {
       assert.equal(typeof value, 'string', 'Invalid extended symbol: ' + value)
 
       const [symbol, contract] = value.split('@')
-      assert(contract != null, 'Missing @contract suffix in extended symbol: ' + value)
+      assert(contract !== null, 'Missing @contract suffix in extended symbol: ' + value)
 
       symbolType.appendByteBuffer(b, symbol)
       contractName.appendByteBuffer(b, contract)
@@ -305,7 +305,7 @@ const ExtendedSymbol = (validation, baseTypes, customTypes) => {
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return 'SYS@contract'
       }
       return value
@@ -324,21 +324,21 @@ const Asset = (validation, baseTypes, customTypes) => {
   return {
     fromByteBuffer (b) {
       const amount = amountType.fromByteBuffer(b)
-      assert(amount != null, 'amount')
+      assert(amount !== null, 'amount')
 
       const sym = symbolType.fromByteBuffer(b)
       const {precision, symbol} = parseAsset(`${sym}`)
-      assert(precision != null, 'precision')
-      assert(symbol != null, 'symbol')
+      assert(precision !== null, 'precision')
+      assert(symbol !== null, 'symbol')
 
       return `${DecimalUnimply(amount, precision)} ${symbol}`
     },
 
     appendByteBuffer (b, value) {
       const {amount, precision, symbol} = parseAsset(value)
-      assert(amount != null, 'amount')
-      assert(precision != null, 'precision')
-      assert(symbol != null, 'symbol')
+      assert(amount !== null, 'amount')
+      assert(precision !== null, 'precision')
+      assert(symbol !== null, 'symbol')
 
       amountType.appendByteBuffer(b, DecimalImply(amount, precision))
       symbolType.appendByteBuffer(b, `${precision},${symbol}`)
@@ -346,22 +346,22 @@ const Asset = (validation, baseTypes, customTypes) => {
 
     fromObject (value) {
       const {amount, precision, symbol} = parseAsset(value)
-      assert(amount != null, 'amount')
-      assert(precision != null, 'precision')
-      assert(symbol != null, 'symbol')
+      assert(amount !== null, 'amount')
+      assert(precision !== null, 'precision')
+      assert(symbol !== null, 'symbol')
 
       return `${DecimalPad(amount, precision)} ${symbol}`
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return '0.0001 SYS'
       }
 
       const {amount, precision, symbol} = parseAsset(value)
-      assert(amount != null, 'amount')
-      assert(precision != null, 'precision')
-      assert(symbol != null, 'symbol')
+      assert(amount !== null, 'amount')
+      assert(precision !== null, 'precision')
+      assert(symbol !== null, 'symbol')
 
       return `${DecimalPad(amount, precision)} ${symbol}`
     }
@@ -407,16 +407,16 @@ const ExtendedAsset = (validation, baseTypes, customTypes) => {
       }
 
       const {amount, precision, symbol, contract} = asset
-      assert(amount != null, 'missing amount')
-      assert(precision != null, 'missing precision')
-      assert(symbol != null, 'missing symbol')
-      assert(contract != null, 'missing contract')
+      assert(amount !== null, 'missing amount')
+      assert(precision !== null, 'missing precision')
+      assert(symbol !== null, 'missing symbol')
+      assert(contract !== null, 'missing contract')
 
       return {amount, precision, symbol, contract}
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return {
           amount: '1.0000',
           precision: 4,
@@ -458,7 +458,7 @@ const SignatureType = (validation, baseTypes) => {
     },
 
     toObject (value) {
-      if (validation.defaults && value == null) {
+      if (validation.defaults && value === null) {
         return 'SIG_K1_bas58signature..'
       }
       const signature = Signature.from(value)
@@ -513,7 +513,7 @@ const abiOverride = structLookup => ({
 
     if(Buffer.isBuffer(object.abi)) {
       b2.append(object.abi)
-    } else if(typeof object.abi == 'object'){
+    } else if(typeof object.abi === 'object'){
       ser.appendByteBuffer(b2, object.abi);
     }
 
@@ -528,7 +528,7 @@ const wasmCodeOverride = config => ({
       const code = object.code.toString()
       if(/^\s*\(module/.test(code)) {
         const {binaryen} = config
-        assert(binaryen != null, 'required: config.binaryen = require("binaryen")')
+        assert(binaryen !== null, 'required: config.binaryen = require("binaryen")')
         if(config.debug) {
           console.log('Assembling WASM..')
         }
@@ -549,7 +549,7 @@ const wasmCodeOverride = config => ({
 */
 const actionDataOverride = (structLookup, forceActionDataHex) => ({
   'action.data.fromByteBuffer': ({fields, object, b, config}) => {
-    const ser = (object.name || '') == '' ? fields.data : structLookup(object.name, object.account)
+    const ser = (object.name || '') === '' ? fields.data : structLookup(object.name, object.account)
     if(ser) {
       b.readVarint32() // length prefix (usefull if object.name is unknown)
       object.data = ser.fromByteBuffer(b, config)
@@ -563,7 +563,7 @@ const actionDataOverride = (structLookup, forceActionDataHex) => ({
   },
 
   'action.data.appendByteBuffer': ({fields, object, b}) => {
-    const ser = (object.name || '') == '' ? fields.data : structLookup(object.name, object.account)
+    const ser = (object.name || '') === '' ? fields.data : structLookup(object.name, object.account)
     if(ser) {
       const b2 = new ByteBuffer(ByteBuffer.DEFAULT_CAPACITY, ByteBuffer.LITTLE_ENDIAN)
       ser.appendByteBuffer(b2, object.data)
@@ -582,7 +582,7 @@ const actionDataOverride = (structLookup, forceActionDataHex) => ({
 
   'action.data.fromObject': ({fields, object, result}) => {
     const {data, name} = object
-    const ser = (name || '') == '' ? fields.data : structLookup(name, object.account)
+    const ser = (name || '') === '' ? fields.data : structLookup(name, object.account)
     if(ser) {
       if(typeof data === 'object') {
         result.data = ser.fromObject(data) // resolve shorthand
@@ -600,7 +600,7 @@ const actionDataOverride = (structLookup, forceActionDataHex) => ({
 
   'action.data.toObject': ({fields, object, result, config}) => {
     const {data, name} = object || {}
-    const ser = (name || '') == '' ? fields.data : structLookup(name, object.account)
+    const ser = (name || '') === '' ? fields.data : structLookup(name, object.account)
     if(!ser) {
       // Types without an ABI will accept hex
       result.data = Buffer.isBuffer(data) ? data.toString('hex') : data

--- a/src/write-api.js
+++ b/src/write-api.js
@@ -81,7 +81,7 @@ function WriteApi(Network, network, config, Transaction) {
   const genTransaction = (structs, merge) => async function(...args) {
     let contracts, options, callback
 
-    if(args[args.length - 1] == null) {
+    if(args[args.length - 1] === null) {
       // callback may be undefined
       args = args.slice(0, args.length - 1)
     }
@@ -208,7 +208,7 @@ function WriteApi(Network, network, config, Transaction) {
 
       const authorization = []
       const providedAuth = options.authorization ? options.authorization : config.authorization
-      const addDefaultAuths = providedAuth == null
+      const addDefaultAuths = providedAuth === null
 
       // Often if the first field in an action is an account name it is
       // also the required authorization.
@@ -308,7 +308,7 @@ function WriteApi(Network, network, config, Transaction) {
           noCallback: true
         }
       })
-      if(ret == null) {
+      if(ret === null) {
         // double-check (code can change)
         throw new Error('Callbacks can not be used when creating a multi-action transaction')
       }
@@ -326,7 +326,7 @@ function WriteApi(Network, network, config, Transaction) {
 
       } else if(typeof value === 'object') {
         // other contract(s) (currency contract for example)
-        if(messageCollector[variableName] == null) {
+        if(messageCollector[variableName] === null) {
           messageCollector[variableName] = {}
         }
         for(const key2 in value) {
@@ -412,9 +412,9 @@ function WriteApi(Network, network, config, Transaction) {
 
     let argHeaders = null
     if( // minimum required headers
-      arg.expiration != null &&
-      arg.ref_block_num != null &&
-      arg.ref_block_prefix != null
+      arg.expiration !== null &&
+      arg.ref_block_num !== null &&
+      arg.ref_block_prefix !== null
     ) {
       const {
         expiration,
@@ -502,7 +502,7 @@ function WriteApi(Network, network, config, Transaction) {
         }
 
         const mock = config.mockTransactions ? config.mockTransactions() : null
-        if(mock != null) {
+        if(mock !== null) {
           assert(/pass|fail/.test(mock), 'mockTransactions should return a string: pass or fail')
           if(mock === 'pass') {
             callback(null, {


### PR DESCRIPTION
## Description
This PR replaces all double equals with triple equals.
(!= or ==) => (!== or ===)

It is considered good practice to use the type-safe equality operators === and !== instead of their regular counterparts == and !=. The reason for this is that == and != do type coercion which follows the rather obscure Abstract Equality Comparison Algorithm. For instance, the following statements are all considered true:

* [] == false
* [] == ![]
* 3 == "03"

If one of those occurs in an innocent-looking statement such as a == b the actual problem is very difficult to spot.

Check this out: https://eslint.org/docs/rules/eqeqeq