### PR TITLE
added optional abiProvider to Api constructor

### DIFF
--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -34,7 +34,7 @@ export interface AuthorityProvider {
 
 /** Retrieves raw ABIs for a specified accountName */
 export interface AbiProvider {
-    getRawAbi: (args: string) => Promise<BinaryAbi>;
+    getRawAbi: (accountName: string) => Promise<BinaryAbi>;
 }
 
 /** Structure for the raw form of ABIs */
@@ -122,7 +122,7 @@ export class Api {
         authorityProvider?: AuthorityProvider,
         abiProvider?: AbiProvider,
         signatureProvider: SignatureProvider,
-        chainId: string,
+        chainId?: string,
         textEncoder?: TextEncoder,
         textDecoder?: TextDecoder,
     }) {

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -7,7 +7,6 @@
 "use strict";
 
 import { Abi, GetInfoResult, JsonRpc, PushTransactionArgs } from "./eosjs-jsonrpc";
-import { base64ToBinary } from "./eosjs-numeric";
 import * as ser from "./eosjs-serialize";
 
 // tslint:disable-next-line
@@ -33,6 +32,12 @@ export interface AuthorityProvider {
     getRequiredKeys: (args: AuthorityProviderArgs) => Promise<string[]>;
 }
 
+/** Retrieves raw ABIs for a specified account_name */
+export interface AbiProvider {
+    getRawAbi: (args: string) => Promise<BinaryAbi>;
+}
+
+/** Structure for the raw form of ABIs */
 export interface BinaryAbi {
     account_name: string;
     abi: Uint8Array;
@@ -78,6 +83,9 @@ export class Api {
     /** Get subset of `availableKeys` needed to meet authorities in a `transaction` */
     public authorityProvider: AuthorityProvider;
 
+    /** Supplies ABIs in raw form (binary) */
+    public abiProvider: AbiProvider;
+
     /** Signs transactions */
     public signatureProvider: SignatureProvider;
 
@@ -103,6 +111,7 @@ export class Api {
      * @param args
      *    * `rpc`: Issues RPC calls
      *    * `authorityProvider`: Get public keys needed to meet authorities in a transaction
+     *    * `abiProvider`: Supply ABIs to retrieve ricardian contracts
      *    * `signatureProvider`: Signs transactions
      *    * `chainId`: Identifies chain
      *    * `textEncoder`: `TextEncoder` instance to use. Pass in `null` if running in a browser
@@ -111,6 +120,7 @@ export class Api {
     constructor(args: {
         rpc: JsonRpc,
         authorityProvider?: AuthorityProvider,
+        abiProvider?: AbiProvider,
         signatureProvider: SignatureProvider,
         chainId: string,
         textEncoder?: TextEncoder,
@@ -118,6 +128,7 @@ export class Api {
     }) {
         this.rpc = args.rpc;
         this.authorityProvider = args.authorityProvider || args.rpc;
+        this.abiProvider = args.abiProvider || args.rpc
         this.signatureProvider = args.signatureProvider;
         this.chainId = args.chainId;
         this.textEncoder = args.textEncoder;
@@ -148,8 +159,7 @@ export class Api {
         }
         let cachedAbi: CachedAbi;
         try {
-            // todo: use get_raw_abi when it becomes available
-            const rawAbi = base64ToBinary((await this.rpc.get_raw_code_and_abi(accountName)).abi);
+            const rawAbi = (await this.abiProvider.getRawAbi(accountName)).abi;
             const abi = this.rawAbiToJson(rawAbi);
             cachedAbi = { rawAbi, abi };
         } catch (e) {

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -32,7 +32,7 @@ export interface AuthorityProvider {
     getRequiredKeys: (args: AuthorityProviderArgs) => Promise<string[]>;
 }
 
-/** Retrieves raw ABIs for a specified account_name */
+/** Retrieves raw ABIs for a specified accountName */
 export interface AbiProvider {
     getRawAbi: (args: string) => Promise<BinaryAbi>;
 }
@@ -111,7 +111,7 @@ export class Api {
      * @param args
      *    * `rpc`: Issues RPC calls
      *    * `authorityProvider`: Get public keys needed to meet authorities in a transaction
-     *    * `abiProvider`: Supply ABIs to retrieve ricardian contracts
+     *    * `abiProvider`: Supplies ABIs in raw form (binary)
      *    * `signatureProvider`: Signs transactions
      *    * `chainId`: Identifies chain
      *    * `textEncoder`: `TextEncoder` instance to use. Pass in `null` if running in a browser
@@ -128,7 +128,7 @@ export class Api {
     }) {
         this.rpc = args.rpc;
         this.authorityProvider = args.authorityProvider || args.rpc;
-        this.abiProvider = args.abiProvider || args.rpc
+        this.abiProvider = args.abiProvider || args.rpc;
         this.signatureProvider = args.signatureProvider;
         this.chainId = args.chainId;
         this.textEncoder = args.textEncoder;

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -4,7 +4,7 @@
 
 // copyright defined in eosjs/LICENSE.txt
 
-import { AuthorityProvider, AuthorityProviderArgs, AbiProvider, BinaryAbi } from "./eosjs-api";
+import { AbiProvider, AuthorityProvider, AuthorityProviderArgs, BinaryAbi } from "./eosjs-api";
 import { base64ToBinary } from "./eosjs-numeric";
 import { convertLegacyPublicKeys } from "./eosjs-numeric";
 import { RpcError } from "./eosjs-rpcerror";
@@ -206,10 +206,10 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
 
     /** calls `/v1/chain/get_raw_code_and_abi` and pulls out unneeded raw wasm code */
     // TODO: use `/v1/chain/get_raw_abi` directly when it becomes available
-    public async getRawAbi(account_name: string): Promise<BinaryAbi> {
-        const rawCodeAndAbi = await this.get_raw_code_and_abi(account_name);
+    public async getRawAbi(accountName: string): Promise<BinaryAbi> {
+        const rawCodeAndAbi = await this.get_raw_code_and_abi(accountName);
         const abi = base64ToBinary(rawCodeAndAbi.abi);
-        return { account_name: rawCodeAndAbi.account_name, abi }
+        return { account_name: rawCodeAndAbi.account_name, abi };
     }
 
     /** Raw call to `/v1/chain/get_table_rows` */


### PR DESCRIPTION
Moved base64ToBinary logic into getRawAbi wrapper function for `/v1/chain/get_raw_code_and_abi` and created interface to an optional abiProvider