### PR TITLE
Replace the use of "Proxy" in ripemd.js to make eosjs compatible to IE11

### DIFF
--- a/src/ripemd.es5.js
+++ b/src/ripemd.es5.js
@@ -328,12 +328,10 @@ var RIPEMD160 = function () {
 			//  The message after padding consists of t 16-word blocks that
 			// are denoted with X_i[j], with 0≤i≤(t − 1) and 0≤j≤15.
 			var X = new Array(t).fill(undefined).map(function (_, i) {
-				return new Proxy(new DataView(padded, i * block_size, block_size), {
-					get: function get(block_view, j) {
-						return block_view.getUint32(j * word_size, true // Little-endian
-						);
-					}
-				});
+				return function (j) {
+					return new DataView(padded, i * block_size, block_size).getUint32(j * word_size, true // Little-endian
+					);
+				};
 			});
 
 			//  The result of RIPEMD-160 is contained in five 32-bit words,
@@ -360,7 +358,7 @@ var RIPEMD160 = function () {
 				    EP = E;
 				for (var j = 0; j < 80; ++j) {
 					// Left rounds
-					var _T = RIPEMD160.add_modulo32(RIPEMD160.rol32(RIPEMD160.add_modulo32(A, RIPEMD160.f(j, B, C, D), X[i][r[j]], RIPEMD160.K(j)), s[j]), E);
+					var _T = RIPEMD160.add_modulo32(RIPEMD160.rol32(RIPEMD160.add_modulo32(A, RIPEMD160.f(j, B, C, D), X[i](r[j]), RIPEMD160.K(j)), s[j]), E);
 					A = E;
 					E = D;
 					D = RIPEMD160.rol32(C, 10);
@@ -368,7 +366,7 @@ var RIPEMD160 = function () {
 					B = _T;
 
 					// Right rounds
-					_T = RIPEMD160.add_modulo32(RIPEMD160.rol32(RIPEMD160.add_modulo32(AP, RIPEMD160.f(79 - j, BP, CP, DP), X[i][rP[j]], RIPEMD160.KP(j)), sP[j]), EP);
+					_T = RIPEMD160.add_modulo32(RIPEMD160.rol32(RIPEMD160.add_modulo32(AP, RIPEMD160.f(79 - j, BP, CP, DP), X[i](rP[j]), RIPEMD160.KP(j)), sP[j]), EP);
 					AP = EP;
 					EP = DP;
 					DP = RIPEMD160.rol32(CP, 10);

--- a/src/ripemd.js
+++ b/src/ripemd.js
@@ -379,18 +379,14 @@ Method #2
 		// are denoted with X_i[j], with 0≤i≤(t − 1) and 0≤j≤15.
 		const X = (new Array(t))
 			.fill(undefined)
-			.map((_, i) => new Proxy(
+			.map((_, i) => j => (
 				new DataView(
 					padded, i * block_size, block_size
-				), {
-				get(block_view, j)
-				{
-					return block_view.getUint32(
-						j * word_size,
-						true // Little-endian
-					);
-				}
-			}));
+				).getUint32(
+					j * word_size,
+					true // Little-endian
+				)
+			));
 
 		//  The result of RIPEMD-160 is contained in five 32-bit words,
 		// which form the internal state of the algorithm. The final
@@ -416,7 +412,7 @@ Method #2
 						RIPEMD160.add_modulo32(
 							A,
 							RIPEMD160.f(j, B, C, D),
-							X[i][r[j]],
+							X[i](r[j]),
 							RIPEMD160.K(j)
 						),
 						s[j]
@@ -440,7 +436,7 @@ Method #2
 								CP,
 								DP
 							),
-							X[i][rP[j]],
+							X[i](rP[j]),
 							RIPEMD160.KP(j)
 						),
 						sP[j]


### PR DESCRIPTION
@tbfleming @chris-allnutt 
Please refer this pull request to https://github.com/EOSIO/eosjs2/issues/76
I am proposing the fix here since we have migrated eosjs2 to this repo.

Background:
While calculating the RIPEMD160 hash with `ripemd.js` in eosjs, `Proxy` is used during the calculation. `Proxy` is not supported in IE11 hence eosjs did not work in IE11.
https://github.com/EOSIO/eosjs/blob/master/src/ripemd.js#L382
https://github.com/EOSIO/eosjs/blob/master/src/ripemd.es5.js#L331

Fix:
Replace the way to access the DataView object with an anonymous function instead of a Proxy. Access it by calling the function directly.

Test:
I have put about 10 input cases for the fixed ripemd160 hash function and the result values are same as the original.
I have included the fix locally for the simple-boilerplate-dapp and the game Elemental Battles. After the fix, both dapps works fine in IE11 now and also works fine in other browsers.

Remark:
Although only `ripemd.es5.js` will be built to the `/dist` folder, I have done the fix on `ripemd.js` first and use babel to compile it into `ripemd.es5.js`. This pull request include fixes for both JS files.

cc @jeffreyssmith2nd @chris-allnutt @rickykung @andriantolie 