### PR TITLE
Signature Providers: Return transaction along with signatures

### DIFF
--- a/src/eosjs-api-interfaces.ts
+++ b/src/eosjs-api-interfaces.ts
@@ -1,6 +1,6 @@
 // copyright defined in eosjs/LICENSE.txt
 
-import { Abi } from "./eosjs-rpc-interfaces";
+import { Abi, PushTransactionArgs } from "./eosjs-rpc-interfaces";
 
 /** Arguments to `getRequiredKeys` */
 export interface AuthorityProviderArgs {
@@ -63,5 +63,5 @@ export interface SignatureProvider {
     getAvailableKeys: () => Promise<string[]>;
 
     /** Sign a transaction */
-    sign: (args: SignatureProviderArgs) => Promise<string[]>;
+    sign: (args: SignatureProviderArgs) => Promise<PushTransactionArgs>;
 }

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -238,13 +238,12 @@ export default class Api {
         const serializedTransaction = this.serializeTransaction(transaction);
         const availableKeys = await this.signatureProvider.getAvailableKeys();
         const requiredKeys = await this.authorityProvider.getRequiredKeys({ transaction, availableKeys });
-        const signatures = await this.signatureProvider.sign({
+        const pushTransactionArgs = await this.signatureProvider.sign({
             chainId: this.chainId,
             requiredKeys,
             serializedTransaction,
             abis,
         });
-        const pushTransactionArgs = { signatures, serializedTransaction };
         if (broadcast) {
             return this.pushSignedTransaction(pushTransactionArgs);
         }

--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -34,8 +34,9 @@ export default class JsSignatureProvider implements SignatureProvider {
         const signBuf = Buffer.concat([
             new Buffer(chainId, "hex"), new Buffer(serializedTransaction), new Buffer(new Uint8Array(32)),
         ]);
-        return requiredKeys.map(
+        const signatures = requiredKeys.map(
             (pub) => ecc.Signature.sign(signBuf, this.keys.get(convertLegacyPublicKey(pub))).toString(),
         );
+        return { signatures, serializedTransaction };
     }
 }

--- a/src/tests/eosjs-jssig.test.ts
+++ b/src/tests/eosjs-jssig.test.ts
@@ -34,9 +34,9 @@ describe("JsSignatureProvider", () => {
         ]);
         const abis: any[] = [];
 
-        const signatures = await provider.sign({ chainId, requiredKeys, serializedTransaction, abis });
+        const signOutput = await provider.sign({ chainId, requiredKeys, serializedTransaction, abis });
 
         expect(eccSignatureSign).toHaveBeenCalledTimes(2);
-        expect(signatures).toEqual([privateKeys[0], privateKeys[2]]);
+        expect(signOutput).toEqual({ signatures: [privateKeys[0], privateKeys[2]], serializedTransaction });
     });
 });


### PR DESCRIPTION
Signature providers may have valid reasons to modify a transaction (i.e., add actions) prior to returning it to the API `transact` method for possible broadcast. This is not possible currently, as they only return signatures, and `transact` uses the same serialized transaction that was passed into the signature provider.

In this PR, the signature provider returns an object with two keys: `signatures` and `serializedTransaction`. `transact` then broadcasts this output.