### PR TITLE
deploys eosjs web build to cdn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,37 @@
+env:
+  global:
+    CDN_BUCKET_NAME="eosio-eosjs"
 sudo: false
 language: node_js
 node_js:
-  - '10.0.0'
+  - '10.0.0'    
 before_install:
-  - npm install -g typescript
+  - yarn global add typescript
+  - yarn global add webpack 
 before_script:
   - source ./scripts/is_latest.sh
 script:
-  - npm run lint
-  - npm run test
+  - yarn run lint
+  - yarn run test
+  - yarn run build-web
 deploy:
-  provider: script
-  script: 
-    - ./scripts/publish.sh
-  on: 
-    tags: true
-    condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh      
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - ./scripts/publish.sh
+    on: 
+      tags: true
+      condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh
+  - provider: s3
+    skip_cleanup: true
+    access_key_id: $S3_USER_ID
+    secret_access_key: $S3_USER_SECRET
+    bucket: "${CDN_BUCKET_NAME}"
+    region: us-west-2
+    local_dir: dist-web
+    upload-dir: $TRAVIS_TAG
+    on: 
+      tags: true
+      condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh
+after_deploy:
+  - echo "CDN base url - https://${CDN_BUCKET_NAME}.s3.amazonaws.com/${TRAVIS_TAG}/"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "jest",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "lint-fix": "tslint -c tslint.json src/**/*.ts --fix",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -50,8 +50,8 @@ make_version
 echo "Pushing to git"
 upload_files
 
-echo "Publish to NPM"
+echo "Build and Publish to NPM"
 
 cp .npmrc.template $HOME/.npmrc 
-npm install
+
 npm publish


### PR DESCRIPTION
This will publish the output of the eosjs web build to a CDN for consumption.  

This also removes the prepublish step in the package.json due to deprecation