### PR TITLE
Add checking type of data to serializeStruct

### DIFF
--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -616,6 +616,9 @@ function deserializeUnknown(buffer: SerialBuffer): SerialBuffer {
 
 function serializeStruct(this: Type, buffer: SerialBuffer, data: any,
                          state = new SerializerState(), allowExtensions = true) {
+    if (typeof data !== "object") {
+        throw new Error("expected object containing data: " + JSON.stringify(data));
+    }
     if (this.base) {
         this.base.serialize(buffer, data, state, allowExtensions);
     }


### PR DESCRIPTION
When using extended_asset, if type of data to quantity is string, an error of 'undefined' occurs.
For example, when using 'extened_asset', send data to quantity with '1.000 EOS', an error occurs. it wants to throw an error and express it explicitly.