### PR TITLE
publish develop branch with edge tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-env:
-  global:
-    CDN_BUCKET_NAME="eosio-eosjs"
 sudo: false
 language: node_js
 node_js:
@@ -8,30 +5,13 @@ node_js:
 before_install:
   - yarn global add typescript
   - yarn global add webpack 
-before_script:
-  - source ./scripts/is_latest.sh
 script:
   - yarn run lint
   - yarn run test
-  - yarn run build-web
 deploy:
   - provider: script
     skip_cleanup: true
     script: 
       - ./scripts/publish.sh
     on: 
-      tags: true
-      condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh
-  - provider: s3
-    skip_cleanup: true
-    access_key_id: $S3_USER_ID
-    secret_access_key: $S3_USER_SECRET
-    bucket: "${CDN_BUCKET_NAME}"
-    region: us-west-2
-    local_dir: dist-web
-    upload-dir: $TRAVIS_TAG
-    on: 
-      tags: true
-      condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh
-after_deploy:
-  - echo "CDN base url - https://${CDN_BUCKET_NAME}.s3.amazonaws.com/${TRAVIS_TAG}/"
+      branch: develop

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,18 +26,17 @@ make_version() {
   git status
   
   # Run the deploy build and increment the package versions
-  # %s is the placeholder for the created tag
-  npm version -no-git-tag-version $TRAVIS_TAG
+  npm version -no-git-tag-version prerelease
 }
 
 upload_files() {
   git commit -a -m "Updating version [skip ci]"
 
   # This make sure the current work area is pushed to the tip of the current branch
-  git push origin HEAD:master  
+  git push origin HEAD:${TRAVIS_BRANCH}  
 }
 
-echo "Running on tag ${TRAVIS_TAG}, branch ${TRAVIS_BRANCH}":
+echo "Running on branch ${TRAVIS_BRANCH}":
 
 echo "Setting up git"
 setup_git
@@ -49,14 +48,8 @@ make_version
 echo "Pushing to git"
 upload_files
 
-echo "Build and Publish to NPM"
+echo "Publish to NPM"
 
 cp .npmrc.template $HOME/.npmrc 
 
-if [[ "$TRAVIS_TAG" == *"-beta"* ]]; then
-  echo "Publishing with beta tag to npm"
-  npm publish --tag beta
-else
-  echo "Publishing with latest tag to npm"
-  npm publish
-fi
+npm publish --tag edge


### PR DESCRIPTION
This is an incremental change to the publish process for eosjs.  This will publish the HEAD of the develop branch as an NPM with the `edge` tag.  The version of the package.json is incremented with with the `prerelease` option.  With the current state of the package.json, this will look like:

v20.0.0-beta2.0

Subsequent commits against the develop branch will continue to increment the prerelease version number:
v20.0.0-beta2.1
v20.0.0-beta2.2

and so on.  

Those interested in utilizing the latest commits to the develop branch can run `npm install eosjs@edge`