### PR TITLE
Restores Edge Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,16 @@ language: node_js
 node_js:
   - '10.0.0'    
 before_install:
+  - npm i -g npm@6.4.1
   - yarn global add typescript
   - yarn global add webpack 
 script:
   - yarn run lint
   - yarn run test
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - ./scripts/publish.sh
+    on: 
+      branch: develop

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,17 +23,14 @@ make_version() {
   git checkout -- .
   
   # Echo the status to the log so that we can see it is OK
-  git status
-  
+  git status 
+
   # Run the deploy build and increment the package versions
-  npm version -no-git-tag-version prerelease
-}
+  current_commit="$(git rev-parse --short HEAD)";
 
-upload_files() {
+  npm version prerelease -preid "${current_commit}" -no-git-tag-version
+
   git commit -a -m "Updating version [skip ci]"
-
-  # This make sure the current work area is pushed to the tip of the current branch
-  git push origin HEAD:${TRAVIS_BRANCH}  
 }
 
 echo "Running on branch ${TRAVIS_BRANCH}":
@@ -44,9 +41,6 @@ setup_git
 echo "Creating new version"
 
 make_version
-
-echo "Pushing to git"
-upload_files
 
 echo "Publish to NPM"
 


### PR DESCRIPTION
This restores edge releases for eosjs.  Commits to the `develop` branch will push an `@edge` version to npm that contains the short commit has that was published.  For example:

If the current version is 1.0.0

Commit 1 with commit hash c8a134 is pushed to develop.  Performing an `npm install eosjs@edge` would pull in 1.0.1-c8a134.0.

This also updates the version of NPM used for builds to 6.4.1 to gain access to the `preid` functionality in `npm version`
