### PR TITLE
Correct import of default property

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import JsSignatureProvider from 'eosjs/dist/eosjs-jssig'; // development only
 Importing using commonJS syntax is supported by NodeJS out of the box.
 ```js
 const { Api, JsonRpc, RpcError } = require('eosjs');
-const JsSignatureProvider = require('eosjs/dist/eosjs-jssig');  // development only
+const JsSignatureProvider = require('eosjs/dist/eosjs-jssig').default;  // development only
 const fetch = require('node-fetch');                            // node only; not needed in browsers
 const { TextEncoder, TextDecoder } = require('util');           // node only; native TextEncoder/Decoder 
 const { TextEncoder, TextDecoder } = require('text-encoding');  // React Native, IE11, and Edge Browsers only

--- a/docs/2.-Transaction-Examples.md
+++ b/docs/2.-Transaction-Examples.md
@@ -6,7 +6,7 @@ The signature provider must contains the private keys corresponsing to the actor
 
 ```javascript
 const { Api, JsonRpc } = require('eosjs');
-const JsSignatureProvider = require('eosjs/dist/eosjs-jssig');  // development only
+const JsSignatureProvider = require('eosjs/dist/eosjs-jssig').default;  // development only
 const fetch = require('node-fetch');                            // node only; not needed in browsers
 const { TextDecoder, TextEncoder } = require('text-encoding');  // node, IE11 and IE Edge Browsers
 


### PR DESCRIPTION
Fixes `TypeError: JsSignatureProvider is not a constructor` for NodeJS and Babel.
Caused by `export default class JsSignatureProvider`.

Babel assigns default exports to the default property. 
So if you use require to import ES6 modules, you need to access the default property.
