### PR TITLE
Update: Support reverse order and show payer option - Fix #324

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ import { Api, JsonRpc, RpcError } from 'eosjs';
 import JsSignatureProvider from 'eosjs/dist/eosjs-jssig'; // development only
 ```
 
-### CommonJS 
+### CommonJS
 
 Importing using commonJS syntax is supported by NodeJS out of the box.
 ```js
 const { Api, JsonRpc, RpcError } = require('eosjs');
 const JsSignatureProvider = require('eosjs/dist/eosjs-jssig');  // development only
 const fetch = require('node-fetch');                            // node only; not needed in browsers
-const { TextEncoder, TextDecoder } = require('util');           // node only; native TextEncoder/Decoder 
+const { TextEncoder, TextDecoder } = require('util');           // node only; native TextEncoder/Decoder
 const { TextEncoder, TextDecoder } = require('text-encoding');  // React Native, IE11, and Edge Browsers only
 ```
 

--- a/docs/4.-Reading blockchain-Examples.md
+++ b/docs/4.-Reading blockchain-Examples.md
@@ -17,15 +17,17 @@ Get the first 10 token balances of account _testacc_.
 ```javascript
 const resp = await rpc.get_table_rows({
     json: true,              // Get the response as json
-    code: 'eosio.token',     // Contract that we target      
-    scope: 'testacc'         // Account that owns the data   
-    table: 'accounts'        // Table name        
-    limit: 10,               // maximum number of rows that we want to get
+    code: 'eosio.token',     // Contract that we target
+    scope: 'testacc'         // Account that owns the data
+    table: 'accounts'        // Table name
+    limit: 10,               // Maximum number of rows that we want to get
+    reverse = false,         // Optional: Get reversed data
+    show_payer = false,      // Optional: Show ram payer
 });
 
 console.log(resp.rows);
 ```
-Output: 
+Output:
 
 ```json
 {
@@ -42,15 +44,17 @@ Output:
 ```javascript
 const resp = await rpc.get_table_rows({
     json: true,                 // Get the response as json
-    code: 'contract',           // Contract that we target         
-    scope: 'contract'           // Account that owns the data        
-    table: 'profiles'           // Table name        
-    lower_bound: 'testacc'      // Table primary key value           
+    code: 'contract',           // Contract that we target
+    scope: 'contract'           // Account that owns the data
+    table: 'profiles'           // Table name
+    lower_bound: 'testacc'      // Table primary key value
     limit: 1,                   // Here we limit to 1 to get only the
+    reverse = false,            // Optional: Get reversed data
+    show_payer = false,         // Optional: Show ram payer
 });
 console.log(resp.rows);
 ```
-Output: 
+Output:
 
 ```json
 {
@@ -64,21 +68,23 @@ Output:
 }
 ```
 
-### Get one row by secondary index 
+### Get one row by secondary index
 
 ```javascript
 const resp = await rpc.get_table_rows({
     json: true,                 // Get the response as json
-    code: 'contract',           // Contract that we target         
-    scope: 'contract'           // Account that owns the data        
-    table: 'profiles'           // Table name        
-    table_key: 'age'            // Table secondaray key name        
-    lower_bound: 21             // Table secondary key value           
-    limit: 1,                   // Here we limit to 1 to get only the
+    code: 'contract',           // Contract that we target
+    scope: 'contract'           // Account that owns the data
+    table: 'profiles'           // Table name
+    table_key: 'age'            // Table secondaray key name
+    lower_bound: 21             // Table secondary key value
+    limit: 1,                   // Here we limit to 1 to get only row
+    reverse = false,            // Optional: Get reversed data
+    show_payer = false,         // Optional: Show ram payer
 });
 console.log(resp.rows);
 ```
-Output: 
+Output:
 
 ```json
 {
@@ -97,7 +103,7 @@ Output:
 ```javascript
 console.log(await rpc.get_currency_balance('eosio.token', 'testacc', 'HAK'));
 ```
-Output: 
+Output:
 
 ```json
 [ "1000000000.0000 HAK" ]
@@ -108,7 +114,7 @@ Output:
 ```javascript
 console.log(await rpc.get_account('testacc'));
 ```
-Output: 
+Output:
 
 ```json
 { "account_name": "testacc",
@@ -123,7 +129,7 @@ Output:
   "net_limit": { "used": -1, "available": -1, "max": -1 },
   "cpu_limit": { "used": -1, "available": -1, "max": -1 },
   "ram_usage": 2724,
-  "permissions": 
+  "permissions":
    [ { "perm_name": "active", "parent": "owner", "required_auth": [] },
      { "perm_name": "owner", "parent": "", "required_auth": [] } ],
   "total_resources": null,
@@ -137,7 +143,7 @@ Output:
 ```javascript
 console.log(await rpc.get_block(1));
 ```
-Output: 
+Output:
 
 ```json
 { "timestamp": "2018-06-01T12:00:00.000",

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -144,6 +144,8 @@ export default class JsonRpc implements AuthorityProvider, AbiProvider {
         index_position = 1,
         key_type = "",
         limit = 10,
+        reverse = false,
+        show_payer = false,
      }: any): Promise<any> {
         return await this.fetch(
             "/v1/chain/get_table_rows", {
@@ -157,6 +159,8 @@ export default class JsonRpc implements AuthorityProvider, AbiProvider {
                 index_position,
                 key_type,
                 limit,
+                reverse,
+                show_payer,
             });
     }
 

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -354,6 +354,8 @@ describe("JSON RPC", () => {
         const indexPosition = 1;
         const keyType = "str";
         const expReturn = { data: "12345" };
+        const reverse = false;
+        const showPayer = false;
         const callParams = {
             json,
             code,
@@ -365,6 +367,8 @@ describe("JSON RPC", () => {
             index_position: indexPosition,
             key_type: keyType,
             limit,
+            reverse,
+            show_payer: showPayer,
         };
         const expParams = {
             body: JSON.stringify(callParams),
@@ -391,6 +395,8 @@ describe("JSON RPC", () => {
         const limit = 10;
         const indexPosition = 1;
         const keyType = "";
+        const reverse = false;
+        const showPayer = false;
         const expReturn = { data: "12345" };
         const callParams = {
             code,
@@ -409,6 +415,8 @@ describe("JSON RPC", () => {
                 index_position: indexPosition,
                 key_type: keyType,
                 limit,
+                reverse,
+                show_payer: showPayer,
             }),
             method: "POST",
         };

--- a/src/tests/web.html
+++ b/src/tests/web.html
@@ -97,7 +97,7 @@
         throw new Error('Web Integration Test Failed Unexpectedly: ' + e.message)
     }
     await waitTwoSeconds();
-    
+
     let failedAsPlanned;
     try {
       failedAsPlanned = true;
@@ -128,7 +128,7 @@
         throw new Error('The final transact call (lacking TAPoS and config) did not fail as expected');
     }
     await waitTwoSeconds();
-    
+
     try {
         failedAsPlanned = true;
         const invalidRpcCall = await rpc.get_block(-1);


### PR DESCRIPTION
## Summary
- Support `reverse` and `show_payer` option in `JsonRpc`
- Remove trailing spaces
- Update examples in the document
- Tested on JungleNet and works fine

## Reference
- [getTableRows in Descending order #324](https://github.com/EOSIO/eosjs/issues/324)
- [Merge pull request #6264 from taokayan/get_table_reverse](https://github.com/EOSIO/eos/blob/ea08cfd3d1a82b634a9e84f971d99708af516c0d/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp#L263)