### PR TITLE
remove babel-runtime package. Should be provided by the hosting app

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/EOSIO/eosjs.git"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "eosjs-ecc": "^4.0.1",
     "text-encoding": "^0.6.4"
   },


### PR DESCRIPTION
As per this issues. 

https://github.com/EOSIO/eosjs/issues/450

babel-runtime should be provided by the hosting application. 