### PR TITLE
verbose npmignore -> concise npminclude

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,30 +1,15 @@
-dist/**/*.test.*
-dist-web/
-docs/
-cypress.json
-cypress/
-examples/
-scripts/
-src/**/*.ts
-src/**/*.js
-src/tests/
-reports/
-.babelrc
-.eslintrc.json
-.github/
-.gitignore
-.idea
-.npmignore
-.npmrc.template
-.nvmrc
-.travis.yml
-CONTRIB.md
-README.md
-tsconfig.json
-tsconfig.*.json
-tslint.json
-typedoc.json
-webpack.*.js
-*.tgz
-yarn.lock
-yarn-error.log
+# Exclude all files by default
+*
+
+# Include distribution bundle but exclude test files if they are built into dist
+!dist/**
+*.test.*
+
+# Include any additional source files which should be bundled
+!src/**/*.abi.json
+
+# Include documentation and version information in bundle
+!README.md
+!CONTRIBUTING.md
+!LICENSE
+!package.json


### PR DESCRIPTION
Benefits include:
- More concise syntax
- Better readability
- More generic selectors