### PR TITLE
Removed unusuable version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The official distribution package can be found at [npm](https://www.npmjs.com/pa
 
 ### NodeJS Dependency
 
-`yarn add eosjs@beta3`
+`yarn add eosjs`
 
 ### Browser Distribution
 


### PR DESCRIPTION
```
$ npm i --save eosjs@beta3
npm ERR! code ETARGET
npm ERR! notarget No matching version found for eosjs@beta3
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

Looks like this version doesn't exist, so I updated the readme to refer to whatever is tagged as the latest version in NPM.