### PR TITLE
Add `get_scheduled_transactions` to jsonrpc

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -125,6 +125,11 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
         return { accountName: rawCodeAndAbi.account_name, abi };
     }
 
+    /** Raw call to `/v1/chain/get_scheduled_transactions` */
+    public async get_scheduled_transactions(json = true, lowerBound = '', limit = 50): Promise<any> {
+        return await this.fetch('/v1/chain/get_scheduled_transactions', { json, lower_bound: lowerBound, limit });
+    }
+
     /** Raw call to `/v1/chain/get_table_rows` */
     public async get_table_rows({
         json = true,

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -341,6 +341,29 @@ describe('JSON RPC', () => {
         expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
     });
 
+    it('calls get_scheduled_transactions', async () => {
+        const expPath = '/v1/chain/get_scheduled_transactions';
+        const json = true;
+        const lowerBound = '';
+        const limit = 50;
+        const expReturn = { data: '12345' };
+        const expParams = {
+            body: JSON.stringify({
+                json,
+                lower_bound: lowerBound,
+                limit,
+            }),
+            method: 'POST',
+        };
+
+        fetchMock.once(JSON.stringify(expReturn));
+
+        const response = await jsonRpc.get_scheduled_transactions();
+
+        expect(response).toEqual(expReturn);
+        expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
+    });
+
     it('calls get_table_rows with all params', async () => {
         const expPath = '/v1/chain/get_table_rows';
         const json = false;


### PR DESCRIPTION
## Change Description
This PR adds support for `/v1/chain/get_scheduled_transactions` to JSON-RPC. (EOSIO/eos#4470)

## API Changes
- [x] API Changes

`get_scheduled_transactions(json: boolean, lowerBound: string, limit: number)` is added.


## Documentation Additions
- [x] Documentation Additions

New API is added, and its usage needs to be documented.