### PR TITLE
Handle context-free data

### DIFF
--- a/src/eosjs-api-interfaces.ts
+++ b/src/eosjs-api-interfaces.ts
@@ -52,6 +52,9 @@ export interface SignatureProviderArgs {
     /** Transaction to sign */
     serializedTransaction: Uint8Array;
 
+    /** Context-free data to sign */
+    serializedContextFreeData?: Uint8Array;
+
     /** ABIs for all contracts with actions included in `serializedTransaction` */
     abis: BinaryAbi[];
 }

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -189,11 +189,13 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     }
 
     /** Push a serialized transaction */
-    public async push_transaction({ signatures, serializedTransaction }: PushTransactionArgs): Promise<any> {
+    public async push_transaction(
+        { signatures, serializedTransaction, serializedContextFreeData }: PushTransactionArgs
+    ): Promise<any> {
         return await this.fetch('/v1/chain/push_transaction', {
             signatures,
             compression: 0,
-            packed_context_free_data: '',
+            packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
             packed_trx: arrayToHex(serializedTransaction),
         });
     }

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -77,4 +77,5 @@ export interface GetRawCodeAndAbiResult {
 export interface PushTransactionArgs {
     signatures: string[];
     serializedTransaction: Uint8Array;
+    serializedContextFreeData?: Uint8Array;
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Add support for context-free data in transactions. Signature providers may optionally support this. `eosjs-jssig.ts` supports it.

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
Several functions and interfaces now have optional fields for handling context-free data.

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Overview of context-free actions and context-free data:
* Context-free data is an optional transaction field containing `bytes[]` (array of array of 8-bit values)
* Context-free actions in contracts may reference this data, but normal actions may not
* Context-free actions are similar to normal actions, but may not reference state. This includes, but is not limited to: tables, authorizations, current time, etc.
* ABI 1.0 and ABI 1.1 do not describe context-free data; it's opaque
* ABI 1.0 and ABI 1.1 do not distinguish between normal and context-free actions. It's up to users to know which is which, and place them in the appropriate `transaction` member (`actions` or `context_free_actions`)
