### PR TITLE
Add support for send_transaction JSON RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -5,7 +5,7 @@
 
 import { AbiProvider, AuthorityProvider, AuthorityProviderArgs, BinaryAbi } from './eosjs-api-interfaces';
 import { base64ToBinary, convertLegacyPublicKeys } from './eosjs-numeric';
-import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs } from "./eosjs-rpc-interfaces" // tslint:disable-line
+import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs, SendTransactionArgs } from "./eosjs-rpc-interfaces" // tslint:disable-line
 import { RpcError } from './eosjs-rpcerror';
 
 function arrayToHex(data: Uint8Array) {
@@ -188,11 +188,23 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
         })).required_keys);
     }
 
-    /** Push a serialized transaction */
+    /** Push a serialized transaction (replaced by send_transaction, but returned format has changed) */
     public async push_transaction(
         { signatures, serializedTransaction, serializedContextFreeData }: PushTransactionArgs
     ): Promise<any> {
         return await this.fetch('/v1/chain/push_transaction', {
+            signatures,
+            compression: 0,
+            packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
+            packed_trx: arrayToHex(serializedTransaction),
+        });
+    }
+
+    /** Send a serialized transaction */
+    public async send_transaction(
+        { signatures, serializedTransaction, serializedContextFreeData }: SendTransactionArgs
+    ): Promise<any> {
+        return await this.fetch('/v1/chain/send_transaction', {
             signatures,
             compression: 0,
             packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -5,7 +5,7 @@
 
 import { AbiProvider, AuthorityProvider, AuthorityProviderArgs, BinaryAbi } from './eosjs-api-interfaces';
 import { base64ToBinary, convertLegacyPublicKeys } from './eosjs-numeric';
-import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs, SendTransactionArgs } from "./eosjs-rpc-interfaces" // tslint:disable-line
+import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs } from "./eosjs-rpc-interfaces" // tslint:disable-line
 import { RpcError } from './eosjs-rpcerror';
 
 function arrayToHex(data: Uint8Array) {
@@ -202,7 +202,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
 
     /** Send a serialized transaction */
     public async send_transaction(
-        { signatures, serializedTransaction, serializedContextFreeData }: SendTransactionArgs
+        { signatures, serializedTransaction, serializedContextFreeData }: PushTransactionArgs
     ): Promise<any> {
         return await this.fetch('/v1/chain/send_transaction', {
             signatures,

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -79,3 +79,10 @@ export interface PushTransactionArgs {
     serializedTransaction: Uint8Array;
     serializedContextFreeData?: Uint8Array;
 }
+
+/** Arguments for `send_transaction` */
+export interface SendTransactionArgs {
+    signatures: string[];
+    serializedTransaction: Uint8Array;
+    serializedContextFreeData?: Uint8Array;
+}

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -79,10 +79,3 @@ export interface PushTransactionArgs {
     serializedTransaction: Uint8Array;
     serializedContextFreeData?: Uint8Array;
 }
-
-/** Arguments for `send_transaction` */
-export interface SendTransactionArgs {
-    signatures: string[];
-    serializedTransaction: Uint8Array;
-    serializedContextFreeData?: Uint8Array;
-}

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -570,6 +570,41 @@ describe('JSON RPC', () => {
         expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
     });
 
+    it('calls send_transaction', async () => {
+        const expPath = '/v1/chain/send_transaction';
+        const signatures = [
+            'George Washington',
+            'John Hancock',
+            'Abraham Lincoln',
+        ];
+        const serializedTransaction = new Uint8Array([
+            0, 16, 32, 128, 255,
+        ]);
+
+        const limit = 50;
+        const expReturn = { data: '12345' };
+        const callParams = {
+            signatures,
+            serializedTransaction,
+        };
+        const expParams = {
+            body: JSON.stringify({
+                signatures,
+                compression: 0,
+                packed_context_free_data: '',
+                packed_trx: '00102080ff',
+            }),
+            method: 'POST',
+        };
+
+        fetchMock.once(JSON.stringify(expReturn));
+
+        const response = await jsonRpc.send_transaction(callParams);
+
+        expect(response).toEqual(expReturn);
+        expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
+    });
+
     it('calls db_size_get', async () => {
         const expPath = '/v1/db_size/get';
         const expReturn = { data: '12345' };


### PR DESCRIPTION
## Change Description
Add `send_transaction` to JSON RPC. Fixes #539.

## API Changes
- [x] API Changes
`send_transaction` API is added to a set of supported JSON RPC.

## Documentation Additions
- [x] Documentation Additions
Newly supported `send_transaction` needs to be documented with returned format. Legacy API `push_transaction` has overhead to convert returned data for backward compatibility.
