### PR TITLE
Fix tapos check

### DIFF
--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -291,7 +291,7 @@ export class Api {
 
     // eventually break out into TransactionValidator class
     private hasRequiredTaposFields({ expiration, ref_block_num, ref_block_prefix, ...transaction }: any): boolean {
-        return !!(expiration && ref_block_num && ref_block_prefix);
+        return !!(expiration && typeof(ref_block_num) === 'number' && typeof(ref_block_prefix) === 'number');
     }
 
 } // Api

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -290,7 +290,7 @@ export class Api {
     }
 
     // eventually break out into TransactionValidator class
-    private hasRequiredTaposFields({ expiration, ref_block_num, ref_block_prefix, ...transaction }: any): boolean {
+    private hasRequiredTaposFields({ expiration, ref_block_num, ref_block_prefix }: any): boolean {
         return !!(expiration && typeof(ref_block_num) === 'number' && typeof(ref_block_prefix) === 'number');
     }
 


### PR DESCRIPTION
## Change Description
Modified the conditional in `hasRequiredTaposFields` to use `typeof() === 'number'` instead of a truthiness check for the fields.  As seen in the excerpt below from the transaction header file, both of these fields are unsigned integers and should be confirmed as numbers to allow the 0 case to pass.

```
uint16_t               ref_block_num       = 0U; ///< specifies a block num in the last 2^16 blocks.
uint32_t               ref_block_prefix    = 0UL; ///< specifies the lower 32 bits of the blockid at get_ref_blocknum
```

Addresses #554 

