### PR TITLE
trimmed off final slash from endpoint with regex

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -30,7 +30,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     constructor(endpoint: string, args:
         { fetch?: (input?: string | Request, init?: RequestInit) => Promise<Response> } = {},
     ) {
-        this.endpoint = endpoint;
+        this.endpoint = endpoint.replace(/\/$/, '');
         if (args.fetch) {
             this.fetchBuiltin = args.fetch;
         } else {

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -2,13 +2,14 @@ import { JsonRpc } from '../eosjs-jsonrpc';
 import { RpcError } from '../eosjs-rpcerror';
 
 describe('JSON RPC', () => {
+    const endpointExtraSlash = 'http://localhost/';
     const endpoint = 'http://localhost';
     const fetchMock = fetch as any;
     let jsonRpc: JsonRpc;
 
     beforeEach(() => {
         fetchMock.resetMocks();
-        jsonRpc = new JsonRpc(endpoint);
+        jsonRpc = new JsonRpc(endpointExtraSlash);
     });
 
     it('throws error bad status', async () => {


### PR DESCRIPTION
- Fixes #558
- Also added extra slash in constructor for `eosjs-jsonrpc.test.ts` to confirm that it will remain working