### PR TITLE
Get block header fallback

### DIFF
--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -3,7 +3,13 @@
  */
 // copyright defined in eosjs/LICENSE.txt
 
-import { AbiProvider, AuthorityProvider, BinaryAbi, CachedAbi, SignatureProvider } from './eosjs-api-interfaces';
+import {
+    AbiProvider,
+    AuthorityProvider,
+    BinaryAbi,
+    CachedAbi,
+    SignatureProvider
+} from './eosjs-api-interfaces';
 import { JsonRpc } from './eosjs-jsonrpc';
 import {
     Abi,
@@ -250,11 +256,12 @@ export class Api {
 
             const taposBlockNumber = info.head_block_num - blocksBehind;
             let refBlock: GetBlockHeaderStateResult | GetBlockResult;
-            if (taposBlockNumber - info.last_irreversible_block_num < 2) {
-                refBlock = await this.rpc.get_block(taposBlockNumber);
-            } else {
+            try {
                 refBlock = await this.rpc.get_block_header_state(taposBlockNumber);
+            } catch (error) {
+                refBlock = await this.rpc.get_block(taposBlockNumber);
             }
+
             transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
         }
 

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -5,7 +5,13 @@
 
 import { AbiProvider, AuthorityProvider, BinaryAbi, CachedAbi, SignatureProvider } from './eosjs-api-interfaces';
 import { JsonRpc } from './eosjs-jsonrpc';
-import { Abi, GetInfoResult, PushTransactionArgs, GetBlockHeaderStateResult, GetBlockResult } from './eosjs-rpc-interfaces';
+import {
+    Abi,
+    GetInfoResult,
+    PushTransactionArgs,
+    GetBlockHeaderStateResult,
+    GetBlockResult
+} from './eosjs-rpc-interfaces';
 import * as ser from './eosjs-serialize';
 
 const abiAbi = require('../src/abi.abi.json');

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -5,7 +5,7 @@
 
 import { AbiProvider, AuthorityProvider, BinaryAbi, CachedAbi, SignatureProvider } from './eosjs-api-interfaces';
 import { JsonRpc } from './eosjs-jsonrpc';
-import { Abi, GetInfoResult, PushTransactionArgs } from './eosjs-rpc-interfaces';
+import { Abi, GetInfoResult, PushTransactionArgs, GetBlockHeaderStateResult, GetBlockResult } from './eosjs-rpc-interfaces';
 import * as ser from './eosjs-serialize';
 
 const abiAbi = require('../src/abi.abi.json');
@@ -241,7 +241,14 @@ export class Api {
             if (!info) {
                 info = await this.rpc.get_info();
             }
-            const refBlock = await this.rpc.get_block_header_state(info.head_block_num - blocksBehind);
+
+            const taposBlockNumber = info.head_block_num - blocksBehind;
+            let refBlock: GetBlockHeaderStateResult | GetBlockResult;
+            if (taposBlockNumber - info.last_irreversible_block_num < 2) {
+                refBlock = await this.rpc.get_block(taposBlockNumber);
+            } else {
+                refBlock = await this.rpc.get_block_header_state(taposBlockNumber);
+            }
             transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
         }
 


### PR DESCRIPTION
## Change Description
In response to #584 


## API Changes
- [x] API Changes
The previous PR actually introduced the API changes, but the changes should be backwards compatible for any consumers of the API. This PR will add a fallback which will fix certain cases where `get_block_header_state` will fail


## Documentation Additions
- [ ] Documentation Additions