### PR TITLE
eosjs-ecc version bump to include ripemdhash updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "babel-runtime": "6.26.0",
-    "eosjs-ecc": "4.0.4",
+    "eosjs-ecc": "4.0.7",
     "text-encoding": "0.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Change Description
Fixes #576 
eosjs-ecc just got a branch merged that fixes ripemd hashing when using the signature provider with applications such as electron. This patch resolves issues while using the signature provider; and bumps the version to 4.0.7 of eosjs-ecc.

This new version of eosjs-ecc includes changes from the last 4 months. The old version excludes these changes and uses a version of eosjs-ecc from a year ago.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
