### PR TITLE
Fix Copying RipeMD on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "test": "jest src/tests/*eosjs*",
     "test-node": "jest src/tests/*node*",
     "test-all": "yarn test && yarn test-node && yarn cypress",
-    "build": "tsc -p ./tsconfig.json && cp src/ripemd.es5.js dist/ripemd.js",
+    "build": "tsc -p ./tsconfig.json && node scripts/copy-ripe-md.js",
     "build-web": "webpack --config webpack.prod.js && webpack --config webpack.debug.js",
     "build-production": "yarn build && yarn build-web && yarn test-all",
     "clean": "rm -rf dist",

--- a/scripts/copy-ripe-md.js
+++ b/scripts/copy-ripe-md.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+var root = __dirname + '\\..\\';
+fs.copyFileSync(root + 'src\\ripemd.es5.js', root + 'dist\\ripemd.js');


### PR DESCRIPTION
## Change Description
I've added a small `.js` script that copies the `ripemd.es5.js` from the `/src` folder to `/dist` folder. On windows we don't have access to `cp` so this is a workaround that will will work on all platforms as it uses the NodeJS `fs` require instead.

This resolves installation issues on `windows`.
