### PR TITLE
Resolve Copying on Multiplatform

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "Talk to eos API",
   "main": "dist/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "test": "jest src/tests/*eosjs*",
     "test-node": "jest src/tests/*node*",
     "test-all": "yarn test && yarn test-node && yarn cypress",
-    "build": "tsc -p ./tsconfig.json && cp src/ripemd.es5.js dist/ripemd.js",
+    "build": "tsc -p ./tsconfig.json && node scripts/copy-ripe-md.js",
     "build-web": "webpack --config webpack.prod.js && webpack --config webpack.debug.js",
     "build-production": "yarn build && yarn build-web && yarn test-all",
     "clean": "rm -rf dist",

--- a/scripts/copy-ripe-md.js
+++ b/scripts/copy-ripe-md.js
@@ -1,3 +1,7 @@
 var fs = require('fs');
-var root = __dirname + '\\..\\';
+var root = __dirname.replace('scripts', '');
+
+if(!fs.existsSync(root + 'dist'))
+    fs.mkdirSync(root + 'dist');
+
 fs.copyFileSync(root + 'src\\ripemd.es5.js', root + 'dist\\ripemd.js');

--- a/scripts/copy-ripe-md.js
+++ b/scripts/copy-ripe-md.js
@@ -1,7 +1,8 @@
 var fs = require('fs');
+var path = require('path');
 var root = __dirname.replace('scripts', '');
 
-if(!fs.existsSync(root + 'dist'))
-    fs.mkdirSync(root + 'dist');
+if(!fs.existsSync(path.join(root + 'dist')))
+    fs.mkdirSync(path.join(root + 'dist'));
 
-fs.copyFileSync(root + 'src\\ripemd.es5.js', root + 'dist\\ripemd.js');
+fs.copyFileSync(path.join(root + 'src/ripemd.es5.js'), path.join(root + 'dist/ripemd.js'));

--- a/scripts/copy-ripe-md.js
+++ b/scripts/copy-ripe-md.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+var root = __dirname + '\\..\\';
+fs.copyFileSync(root + 'src\\ripemd.es5.js', root + 'dist\\ripemd.js');


### PR DESCRIPTION
Added a small script that copies `ripemd.es5.js` to the `dist` folder. Otherwise this repo does not currently work on windows.
