### PR TITLE
Remove automatic sorting of authorizations

### DIFF
--- a/src/structs.js
+++ b/src/structs.js
@@ -68,7 +68,6 @@ module.exports = (config = {}, extendedSchema) => {
 
   // Do not sort transaction actions
   config.sort = Object.assign({}, config.sort)
-  config.sort['action.authorization'] = true
   config.sort['signed_transaction.signature'] = true
   config.sort['authority.accounts'] = true
   config.sort['authority.keys'] = true

--- a/src/write-api.js
+++ b/src/write-api.js
@@ -269,9 +269,6 @@ function WriteApi(Network, network, config, Transaction) {
         }
       }
 
-      tr.actions[0].authorization.sort((a, b) =>
-        a.actor > b.actor ? 1 : a.actor < b.actor ? -1 : 0)
-
       // multi-action transaction support
       if(!optionOverrides.messageOnly) {
         transactionArg(tr, options, callback)


### PR DESCRIPTION
## Change Description

Removed the sorting of `action.authorization`.

The sorting of authorizations causes issues with the `ONLY_BILL_FIRST_AUTHORIZER` feature, causing the first biller to always be the first alphabetically despite what is specified when crafting the transaction.

These changes allow specifying an order of the authorizations. I could not find the justification for this sorting in the first place, or anything within `eosjs-ecc@4.0.4` or eosjs-api@7.0.4` that required this ordering. A reason may exist (or have existed) that I am unable to determine - but as far as I'm aware this shouldn't impact anything negatively.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions