### PR TITLE
* fix hash() misuse

### DIFF
--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -30,7 +30,7 @@ function digestFromSerializedData(
         new Buffer(serializedTransaction),
         new Buffer(
             serializedContextFreeData ?
-                new Uint8Array(e.hash(serializedContextFreeData).update(serializedContextFreeData).digest()) :
+                new Uint8Array(e.hash().update(serializedContextFreeData).digest()) :
                 new Uint8Array(32)
         ),
     ]);


### PR DESCRIPTION
secp256k1's hash() is sha256 from hash.js, its constructor does NOT have any parameter.