### PR TITLE
Support max_net_usage_words and max_cpu_usage_ms headers

### DIFF
--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -211,7 +211,7 @@ export class Api {
      *      use it as a reference for TAPoS, and expire the transaction `expireSeconds` after that block's time.
      * @returns node response if `broadcast`, `{signatures, serializedTransaction}` if `!broadcast`
      */
-    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds }:
+    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds, maxNetUsageWords, maxCpuUsageMs }:
         { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number; maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
         let info: GetInfoResult;
 

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -212,7 +212,7 @@ export class Api {
      * @returns node response if `broadcast`, `{signatures, serializedTransaction}` if `!broadcast`
      */
     public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds }:
-        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number; } = {}): Promise<any> {
+        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number; maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
         let info: GetInfoResult;
 
         if (!this.chainId) {
@@ -226,6 +226,14 @@ export class Api {
             }
             const refBlock = await this.rpc.get_block(info.head_block_num - blocksBehind);
             transaction = { ...ser.transactionHeader(refBlock, expireSeconds), ...transaction };
+        }
+
+        if (maxNetUsageWords) {
+            transaction = { max_net_usage_words: maxNetUsageWords, ...transaction };
+        }
+
+        if (maxCpuUsageMs) {
+            transaction = { max_cpu_usage_ms: maxCpuUsageMs, ...transaction };
         }
 
         if (!this.hasRequiredTaposFields(transaction)) {

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -211,8 +211,10 @@ export class Api {
      *      use it as a reference for TAPoS, and expire the transaction `expireSeconds` after that block's time.
      * @returns node response if `broadcast`, `{signatures, serializedTransaction}` if `!broadcast`
      */
-    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds, maxNetUsageWords, maxCpuUsageMs }:
-        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number; maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
+    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds, 
+			maxNetUsageWords, maxCpuUsageMs }:
+        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: 
+			number; maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
         let info: GetInfoResult;
 
         if (!this.chainId) {

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -211,10 +211,10 @@ export class Api {
      *      use it as a reference for TAPoS, and expire the transaction `expireSeconds` after that block's time.
      * @returns node response if `broadcast`, `{signatures, serializedTransaction}` if `!broadcast`
      */
-    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds, 
-			maxNetUsageWords, maxCpuUsageMs }:
-        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: 
-			number; maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
+    public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds,
+		    maxNetUsageWords, maxCpuUsageMs }:
+        { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number;
+		    maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
         let info: GetInfoResult;
 
         if (!this.chainId) {

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -212,9 +212,9 @@ export class Api {
      * @returns node response if `broadcast`, `{signatures, serializedTransaction}` if `!broadcast`
      */
     public async transact(transaction: any, { broadcast = true, sign = true, blocksBehind, expireSeconds,
-		    maxNetUsageWords, maxCpuUsageMs }:
+            maxNetUsageWords, maxCpuUsageMs }:
         { broadcast?: boolean; sign?: boolean; blocksBehind?: number; expireSeconds?: number;
-		    maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
+            maxNetUsageWords?: number; maxCpuUsageMs?: number; } = {}): Promise<any> {
         let info: GetInfoResult;
 
         if (!this.chainId) {


### PR DESCRIPTION
Added support for the new headers of transaction.

```js
let response = await api.transact({
		actions: [{
			account: contract,
			name: action,
			authorization: authorization,
			data: data,
		}]
	}, {
		blocksBehind: 3,
		expireSeconds: 60,
		maxNetUsageWords: 10,
		maxCpuUsageMs: 1
	})
```