### PR TITLE
Additionally accept number equal to 1 or 0 while validating data type of bool during serialization.

### DIFF
--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -775,8 +775,8 @@ export function createInitialTypes(): Map<string, Type> {
         bool: createType({
             name: 'bool',
             serialize(buffer: SerialBuffer, data: boolean) {
-                if (typeof data !== 'boolean') {
-                    throw new Error('Expected true or false');
+                if ( !(typeof data === 'boolean' || typeof data === 'number' && ( data === 1 || data === 0))) {
+                    throw new Error('Expected boolean or number equal to 1 or 0');
                 }
                 buffer.push(data ? 1 : 0);
             },


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
**Change:**
For the validation of data type of bool during serialization, additionally accept number which equal to 1 or 0.

**Reason of the change:**
You could see there is a `buffer.push(data ? 1 : 0);` just below the changed line. It converts all boolean value to 1 or 0.
Hence, if we fetch the payload in an action which is pushed by eosjs before, all boolean fields would become 1 or 0. If we repeat the same payload with the field using value of 1 or 0, it will be invalidated during the check because the check only accept boolean as the data type.

In our latest eosio-explorer required feature, there is a repeat push action feature which depends on the last fetched payload and it will be blocked by the check ( not accepting 1 or 0 ). We need this change in eosjs for us to finish the feature.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
