### PR TITLE
Accept number equal to 1 or 0 while checking data type of bool.

### DIFF
--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -800,8 +800,8 @@ export function createInitialTypes(): Map<string, Type> {
         bool: createType({
             name: 'bool',
             serialize(buffer: SerialBuffer, data: boolean) {
-                if (typeof data !== 'boolean') {
-                    throw new Error('Expected true or false');
+                if ( !(typeof data === 'boolean' || typeof data === 'number' && ( data === 1 || data === 0))) {
+                    throw new Error('Expected boolean or number equal to 1 or 0');
                 }
                 buffer.push(data ? 1 : 0);
             },

--- a/src/tests/eosjs-serialize.test.ts
+++ b/src/tests/eosjs-serialize.test.ts
@@ -1,0 +1,82 @@
+import { ec } from 'elliptic';
+
+import { createInitialTypes, Type, SerialBuffer } from '../eosjs-serialize';
+
+describe('Serialize', () => {
+    let types: Map<string, Type>;
+
+    beforeAll(() => {
+        types = createInitialTypes();
+    });
+
+    it('should be able to createInitialTypes', () => {
+        expect(types).toBeTruthy();
+    });
+
+    describe('bool', () => {
+        let boolType: Type;
+        let mockedBuffer: SerialBuffer;
+
+        const shouldThrowErrorForValue = (value: any) => {
+            try {
+                boolType.serialize(mockedBuffer, value);
+            } catch (e) {
+                expect(e.message).toBe('Expected boolean or number equal to 1 or 0');
+            }
+        };
+
+        const shouldNotThrowErrorForValue = (value: any) => {
+            expect(() => {
+                boolType.serialize(mockedBuffer, value);
+            }).not.toThrow();
+        };
+
+        beforeAll(() => {
+            boolType = types.get('bool');
+            mockedBuffer = Object.create(SerialBuffer);
+            mockedBuffer.push = jest.fn().mockImplementation((value) => {
+                return;
+            });
+        });
+
+        it('should be able to create bool type', () => {
+            expect(boolType).toBeTruthy();
+        });
+
+        it('should throw error when calling serialize when type is not boolean or number', () => {
+            const dataValue = 'string';
+
+            shouldThrowErrorForValue(dataValue);
+        });
+
+        it('should throw error when calling serialize when number that is not 1 or 0', () => {
+            const dataValue = 10;
+
+            shouldThrowErrorForValue(dataValue);
+        });
+
+        it('should not throw error when calling serialize with false', () => {
+            const dataValue = false;
+
+            shouldNotThrowErrorForValue(dataValue);
+        });
+
+        it('should not throw error when calling serialize with true', () => {
+            const dataValue = true;
+
+            shouldNotThrowErrorForValue(dataValue);
+        });
+
+        it('should not throw error when calling serialize with 0', () => {
+            const dataValue = 0;
+
+            shouldNotThrowErrorForValue(dataValue);
+        });
+
+        it('should not throw error when calling serialize with 1', () => {
+            const dataValue = 1;
+
+            shouldNotThrowErrorForValue(dataValue);
+        });
+    });
+});


### PR DESCRIPTION
## Change Description
Change:
For the validation of data type of bool during serialization, additionally accept number which equal to 1 or 0. Closing https://github.com/EOSIO/eosjs/pull/624 in favor of this PR due to adding tests and switching base branch to `develop`.

Reason of the change:
You could see there is a buffer.push(data ? 1 : 0); just below the changed line. It converts all boolean value to 1 or 0.
Hence, if we fetch the payload in an action which is pushed by eosjs before, all boolean fields would become 1 or 0. If we repeat the same payload with the field using value of 1 or 0, it will be invalidated during the check because the check only accept boolean as the data type.

In our latest eosio-explorer required feature, there is a repeat push action feature which depends on the last fetched payload and it will be blocked by the check ( not accepting 1 or 0 ). We need this change in eosjs for us to finish the feature.


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
