### PR TITLE
Creates a RpcError on null endpoint

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -30,6 +30,9 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     constructor(endpoint: string, args:
         { fetch?: (input?: string | Request, init?: RequestInit) => Promise<Response> } = {},
     ) {
+        if (endpoint === null) {
+            throw new RpcError({message: 'JsonRpc constructor requires an endpoint'});
+        }
         this.endpoint = endpoint.replace(/\/$/, '');
         if (args.fetch) {
             this.fetchBuiltin = args.fetch;

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -12,6 +12,19 @@ describe('JSON RPC', () => {
         jsonRpc = new JsonRpc(endpointExtraSlash);
     });
 
+    it('throws error null endpoint', () => {
+        let actMessage = '';
+        const expMessage = 'JsonRpc constructor requires an endpoint';
+        try {
+            jsonRpc = new JsonRpc(null);
+        } catch (e) {
+            expect(e).toBeInstanceOf(RpcError);
+            actMessage = e.message;
+        }
+
+        expect(actMessage).toEqual(expMessage);
+    });
+
     it('throws error bad status', async () => {
         let actMessage = '';
         const expMessage = 'Not Found';


### PR DESCRIPTION
## Change Description
Some packages were using null for new JsonRpc objects. Typescript allows null as a possible input for the endpoint string: https://www.typescriptlang.org/docs/handbook/advanced-types.html#nullable-types.  This PR sends an error with the use of null.

See also: https://github.com/EOSIO/eosio-reference-chrome-extension-authenticator-app/pull/37#pullrequestreview-333637260

## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
