### PR TITLE
Allows null endpoint by adjusting to empty string

### DIFF
--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -30,7 +30,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     constructor(endpoint: string, args:
         { fetch?: (input?: string | Request, init?: RequestInit) => Promise<Response> } = {},
     ) {
-        this.endpoint = endpoint.replace(/\/$/, '');
+        this.endpoint = (endpoint || '').replace(/\/$/, '');
         if (args.fetch) {
             this.fetchBuiltin = args.fetch;
         } else {

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -12,6 +12,11 @@ describe('JSON RPC', () => {
         jsonRpc = new JsonRpc(endpointExtraSlash);
     });
 
+    it('instantiates successfully', () => {
+        jsonRpc = new JsonRpc(null);
+        expect(jsonRpc).toBeInstanceOf(JsonRpc);
+    });
+
     it('throws error bad status', async () => {
         let actMessage = '';
         const expMessage = 'Not Found';


### PR DESCRIPTION
## Change Description
Some packages were using null for new JsonRpc objects. Typescript allows null as a possible input for the endpoint string: https://www.typescriptlang.org/docs/handbook/advanced-types.html#nullable-types.  This PR allows null by replacing it with an empty string.

See also: https://github.com/EOSIO/eosio-reference-chrome-extension-authenticator-app/pull/37#pullrequestreview-333637260

## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
