### PR TITLE
Elliptic p256 compatibility support

### DIFF
--- a/src/PrivateKey.ts
+++ b/src/PrivateKey.ts
@@ -12,7 +12,6 @@ export class PrivateKey {
 
     /** Instantiate private key from an `elliptic`-format private key */
     public static fromElliptic(privKey: ec.KeyPair, keyType = KeyType.k1): PrivateKey {
-        const privArray = privKey.getPrivate().toArray();
         return new PrivateKey({
             type: keyType,
             data: privKey.getPrivate().toBuffer(),
@@ -21,19 +20,15 @@ export class PrivateKey {
 
     /** Instantiate private key from an EOSIO-format private key */
     public static fromString(keyString: string): PrivateKey {
-        const key: Key = stringToPrivateKey(keyString);
-        if (key.type !== KeyType.k1) {
-            throw new Error('Key type isn\'t k1');
-        }
-        return new PrivateKey(key);
+        return new PrivateKey(stringToPrivateKey(keyString));
     }
 
     /** Export private key as `elliptic`-format private key */
     public toElliptic(ecurve?: ec) {
         /** expensive to construct; so we do it only as needed */
         if (!ecurve) {
-            if (this.key.type === KeyType.r1) {
-                ecurve = new ec('secp256r1') as any;
+            if (this.key.type === KeyType.r1 || this.key.type === KeyType.wa) {
+                ecurve = new ec('p256') as any;
             } else {
                 ecurve = new ec('secp256k1') as any;
             }
@@ -44,5 +39,9 @@ export class PrivateKey {
     /** Export private key as EOSIO-format private key */
     public toString(): string {
         return privateKeyToString(this.key);
+    }
+
+    public getType(): KeyType {
+        return this.key.type;
     }
 }

--- a/src/PrivateKey.ts
+++ b/src/PrivateKey.ts
@@ -11,7 +11,7 @@ export class PrivateKey {
     constructor(private key: Key) {}
 
     /** Instantiate private key from an `elliptic`-format private key */
-    public static fromElliptic(privKey: ec.KeyPair, keyType = KeyType.k1): PrivateKey {
+    public static fromElliptic(privKey: ec.KeyPair, keyType: KeyType): PrivateKey {
         return new PrivateKey({
             type: keyType,
             data: privKey.getPrivate().toBuffer(),

--- a/src/PublicKey.ts
+++ b/src/PublicKey.ts
@@ -34,8 +34,8 @@ export class PublicKey {
     public toElliptic(ecurve?: ec): ec.KeyPair {
         /** expensive to construct; so we do it only as needed */
         if (!ecurve) {
-            if (this.key.type === KeyType.r1) {
-                ecurve = new ec('secp256r1') as any;
+            if (this.key.type === KeyType.r1 || this.key.type === KeyType.wa) {
+                ecurve = new ec('p256') as any;
             } else {
                 ecurve = new ec('secp256k1') as any;
             }
@@ -43,5 +43,9 @@ export class PublicKey {
         return ecurve.keyPair({
             pub: new Buffer(this.key.data),
         });
+    }
+
+    public getType(): KeyType {
+        return this.key.type;
     }
 }

--- a/src/PublicKey.ts
+++ b/src/PublicKey.ts
@@ -16,7 +16,7 @@ export class PublicKey {
     }
 
     /** Instantiate public key from an `elliptic`-format public key */
-    public static fromElliptic(publicKey: ec.KeyPair, keyType: KeyType = KeyType.k1): PublicKey {
+    public static fromElliptic(publicKey: ec.KeyPair, keyType: KeyType): PublicKey {
         const x = publicKey.getPublic().getX().toArray();
         const y = publicKey.getPublic().getY().toArray();
         return new PublicKey({

--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -19,7 +19,7 @@ export class Signature {
     }
 
     /** Instantiate Signature from an `elliptic`-format Signature */
-    public static fromElliptic(ellipticSig: ec.Signature, keyType: KeyType = KeyType.k1): Signature {
+    public static fromElliptic(ellipticSig: ec.Signature, keyType: KeyType): Signature {
         const r = ellipticSig.r.toArray();
         const s = ellipticSig.s.toArray();
         let eosioRecoveryParam;

--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -19,16 +19,21 @@ export class Signature {
     }
 
     /** Instantiate Signature from an `elliptic`-format Signature */
-    public static fromElliptic(ellipticSig: ec.Signature): Signature {
+    public static fromElliptic(ellipticSig: ec.Signature, keyType: KeyType = KeyType.k1): Signature {
         const r = ellipticSig.r.toArray();
         const s = ellipticSig.s.toArray();
-        let eosioRecoveryParam = ellipticSig.recoveryParam + 27;
-        if (ellipticSig.recoveryParam <= 3) {
-            eosioRecoveryParam += 4;
+        let eosioRecoveryParam;
+        if (keyType === KeyType.k1) {
+            eosioRecoveryParam = ellipticSig.recoveryParam + 27;
+            if (ellipticSig.recoveryParam <= 3) {
+                eosioRecoveryParam += 4;
+            }
+        } else if (keyType === KeyType.r1 || keyType === KeyType.wa) {
+            eosioRecoveryParam = ellipticSig.recoveryParam;
         }
         const sigData = new Uint8Array([eosioRecoveryParam].concat(r, s));
         return new Signature({
-            type: KeyType.k1,
+            type: keyType,
             data: sigData,
         });
     }
@@ -45,9 +50,14 @@ export class Signature {
         const r = new BN(this.signature.data.slice(1, lengthOfR + 1));
         const s = new BN(this.signature.data.slice(lengthOfR + 1, lengthOfR + lengthOfS + 1));
 
-        let ellipticRecoveryBitField = this.signature.data[0] - 27;
-        if (ellipticRecoveryBitField > 3) {
-            ellipticRecoveryBitField -= 4;
+        let ellipticRecoveryBitField;
+        if (this.signature.type === KeyType.k1) {
+            ellipticRecoveryBitField = this.signature.data[0] - 27;
+            if (ellipticRecoveryBitField > 3) {
+                ellipticRecoveryBitField -= 4;
+            }
+        } else if (this.signature.type === KeyType.r1 || this.signature.type === KeyType.wa) {
+            ellipticRecoveryBitField = this.signature.data[0];
         }
         const recoveryParam = ellipticRecoveryBitField & 3;
         return { r, s, recoveryParam };
@@ -61,5 +71,9 @@ export class Signature {
     /** Export Signature in binary format */
     public toBinary(): Uint8Array {
         return this.signature.data;
+    }
+
+    public getType(): KeyType {
+        return this.signature.type;
     }
 }

--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -78,7 +78,7 @@ class JsSignatureProvider implements SignatureProvider {
 
             do {
                 const ellipticSig = privKey.sign(digest, { canonical: true, pers: [++tries] });
-                sig = Signature.fromElliptic(ellipticSig);
+                sig = Signature.fromElliptic(ellipticSig, KeyType.k1);
             } while (!isCanonical(sig.toBinary()));
 
             signatures.push(sig.toString());

--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -48,9 +48,10 @@ class JsSignatureProvider implements SignatureProvider {
     /** @param privateKeys private keys to sign with */
     constructor(privateKeys: string[]) {
         for (const k of privateKeys) {
-            const priv = PrivateKey.fromString(k).toElliptic(defaultEc);
-            const pubStr = PublicKey.fromElliptic(priv, KeyType.k1).toString();
-            this.keys.set(pubStr, priv);
+            const priv = PrivateKey.fromString(k);
+            const privElliptic = priv.toElliptic();
+            const pubStr = PublicKey.fromElliptic(privElliptic, priv.getType()).toString();
+            this.keys.set(pubStr, privElliptic);
             this.availableKeys.push(pubStr);
         }
     }

--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -69,6 +69,7 @@ class JsSignatureProvider implements SignatureProvider {
 
         const signatures = [] as string[];
         for (const key of requiredKeys) {
+            const publicKey = PublicKey.fromString(key);
             const privKey = this.keys.get(convertLegacyPublicKey(key));
             let tries = 0;
             let sig: Signature;
@@ -78,7 +79,7 @@ class JsSignatureProvider implements SignatureProvider {
 
             do {
                 const ellipticSig = privKey.sign(digest, { canonical: true, pers: [++tries] });
-                sig = Signature.fromElliptic(ellipticSig, KeyType.k1);
+                sig = Signature.fromElliptic(ellipticSig, publicKey.getType());
             } while (!isCanonical(sig.toBinary()));
 
             signatures.push(sig.toString());

--- a/src/tests/eosjs-ecc-verification-stress.test.js
+++ b/src/tests/eosjs-ecc-verification-stress.test.js
@@ -7,6 +7,7 @@ const { Signature, PrivateKey, PublicKey } = require('../eosjs-key-conversions')
 const {
     JsSignatureProvider,
 } = require('../eosjs-jssig');
+const { KeyType } = require('../eosjs-numeric');
 const { SignatureProviderArgs } = require('../eosjs-api-interfaces');
 
 describe('JsSignatureProvider', () => {
@@ -61,7 +62,7 @@ describe('JsSignatureProvider', () => {
                 ellipticSig.recoveryParam
             );
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const eccValid = ecc.verify(eccSig, dataAsString, eccKPub);
             const ellipticValid = ellipticEc.verify(
@@ -102,8 +103,8 @@ describe('JsSignatureProvider', () => {
             );
 
             const recoveredEllipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(recoveredEllipticKPub).toString()).toEqual(PublicKey.fromString(recoveredKPub).toString());
-            expect(PublicKey.fromElliptic(recoveredEllipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(recoveredEllipticKPub, KeyType.k1).toString()).toEqual(PublicKey.fromString(recoveredKPub).toString());
+            expect(PublicKey.fromElliptic(recoveredEllipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const ellipticValid = ellipticEc.verify(
                 ellipticHashedStringAsBuffer,
@@ -126,7 +127,7 @@ describe('JsSignatureProvider', () => {
             const ellipticHashedStringAsBuffer = Buffer.from(ellipticEc.hash().update(dataAsString).digest(), 'hex');
 
             const ellipticSig = KPrivElliptic.sign(ellipticHashedStringAsBuffer);
-            const ellipticSigAsString = Signature.fromElliptic(ellipticSig).toString();
+            const ellipticSigAsString = Signature.fromElliptic(ellipticSig, KeyType.k1).toString();
 
             const recoveredKPub = ecc.recover(ellipticSigAsString, dataAsString);
             const ellipticRecoveredKPub = ellipticEc.recoverPubKey(
@@ -135,7 +136,7 @@ describe('JsSignatureProvider', () => {
                 ellipticSig.recoveryParam
             );
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const eccValid = ecc.verify(ellipticSigAsString, dataAsString, recoveredKPub);
             expect(eccValid).toEqual(true);

--- a/src/tests/eosjs-ecc-verification.test.js
+++ b/src/tests/eosjs-ecc-verification.test.js
@@ -7,6 +7,7 @@ const { Signature, PrivateKey, PublicKey } = require('../eosjs-key-conversions')
 const {
     JsSignatureProvider,
 } = require('../eosjs-jssig');
+const { KeyType } = require('../eosjs-numeric');
 const { SignatureProviderArgs } = require('../eosjs-api-interfaces');
 
 describe('JsSignatureProvider', () => {
@@ -61,7 +62,7 @@ describe('JsSignatureProvider', () => {
                 ellipticSig.recoveryParam
             );
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const eccValid = ecc.verify(eccSig, dataAsString, eccKPub);
             const ellipticValid = ellipticEc.verify(
@@ -98,8 +99,8 @@ describe('JsSignatureProvider', () => {
             );
 
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(PublicKey.fromString(recoveredKPub).toString());
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(PublicKey.fromString(recoveredKPub).toString());
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const ellipticValid = ellipticEc.verify(
                 ellipticHashedStringAsBuffer,
@@ -122,7 +123,7 @@ describe('JsSignatureProvider', () => {
             const ellipticHashedStringAsBuffer = Buffer.from(ellipticEc.hash().update(dataAsString).digest(), 'hex');
 
             const ellipticSig = KPrivElliptic.sign(ellipticHashedStringAsBuffer);
-            const ellipticSigAsString = Signature.fromElliptic(ellipticSig).toString();
+            const ellipticSigAsString = Signature.fromElliptic(ellipticSig, KeyType.k1).toString();
 
             const recoveredKPub = ecc.recover(ellipticSigAsString, dataAsString);
             const ellipticRecoveredKPub = ellipticEc.recoverPubKey(
@@ -131,7 +132,7 @@ describe('JsSignatureProvider', () => {
                 ellipticSig.recoveryParam
             );
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[idx]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[idx]);
 
             const eccValid = ecc.verify(ellipticSigAsString, dataAsString, recoveredKPub);
             expect(eccValid).toEqual(true);

--- a/src/tests/eosjs-jssig.test.ts
+++ b/src/tests/eosjs-jssig.test.ts
@@ -90,7 +90,7 @@ describe('JsSignatureProvider', () => {
 
         const sig: Signature = Signature.fromString(signOutput.signatures[0]);
         const ellipticSig: ec.Signature = sig.toElliptic();
-        const eosSig = Signature.fromElliptic(ellipticSig);
+        const eosSig = Signature.fromElliptic(ellipticSig, KeyType.k1);
         expect(sig).toEqual(eosSig);
     });
 
@@ -121,21 +121,21 @@ describe('JsSignatureProvider', () => {
         it('ensure public key functions are actual inverses of each other', async () => {
             const eosioPubKey = PublicKey.fromString(k1FormatPublicKeys[0]);
             const ellipticPubKey = eosioPubKey.toElliptic();
-            const finalEosioKeyAsK1String = PublicKey.fromElliptic(ellipticPubKey).toString();
+            const finalEosioKeyAsK1String = PublicKey.fromElliptic(ellipticPubKey, KeyType.k1).toString();
             expect(finalEosioKeyAsK1String).toEqual(k1FormatPublicKeys[0]);
         });
 
         it('verify that PUB_K1_ and Legacy pub formats are consistent', () => {
             const eosioLegacyPubKey = legacyPublicKeys[0];
             const ellipticPubKey = PublicKey.fromString(eosioLegacyPubKey).toElliptic();
-            expect(PublicKey.fromElliptic(ellipticPubKey).toString()).toEqual(k1FormatPublicKeys[0]);
+            expect(PublicKey.fromElliptic(ellipticPubKey, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[0]);
         });
 
         it('ensure private key functions are actual inverses of each other', async () => {
             const priv = privateKeys[0];
             const privEosioKey = PrivateKey.fromString(priv);
             const privEllipticKey = privEosioKey.toElliptic();
-            const finalEosioKeyAsString = PrivateKey.fromElliptic(privEllipticKey).toString();
+            const finalEosioKeyAsString = PrivateKey.fromElliptic(privEllipticKey, KeyType.k1).toString();
             expect(privEosioKey.toString()).toEqual(finalEosioKeyAsString);
         });
 
@@ -149,14 +149,14 @@ describe('JsSignatureProvider', () => {
             // const ellipticHashedString = Buffer.from(hashedData);
 
             const ellipticSig = KPrivElliptic.sign(ellipticHashedString);
-            // expect(Signature.fromElliptic(ellipticSig).toString()).toEqual(signatures[0]);
+            // expect(Signature.fromElliptic(ellipticSig, KeyType.k1).toString()).toEqual(signatures[0]);
             const ellipticRecoveredKPub = ellipticEc.recoverPubKey(
                 ellipticHashedString,
                 ellipticSig,
                 ellipticSig.recoveryParam
             );
             const ellipticKPub = ellipticEc.keyFromPublic(ellipticRecoveredKPub);
-            expect(PublicKey.fromElliptic(ellipticKPub).toString()).toEqual(k1FormatPublicKeys[0]);
+            expect(PublicKey.fromElliptic(ellipticKPub, KeyType.k1).toString()).toEqual(k1FormatPublicKeys[0]);
             const ellipticValid = ellipticEc.verify(
                 ellipticHashedString,
                 ellipticSig,
@@ -192,7 +192,7 @@ describe('JsSignatureProvider', () => {
             // const ellipticHashedString = Buffer.from(hashedData);
 
             const ellipticSig = KPrivElliptic.sign(ellipticHashedString);
-            // expect(Signature.fromElliptic(ellipticSig).toString()).toEqual(signatures[0]);
+            // expect(Signature.fromElliptic(ellipticSig, KeyType.r1).toString()).toEqual(signatures[0]);
             const ellipticRecoveredKPub = ellipticEc.recoverPubKey(
                 ellipticHashedString,
                 ellipticSig,

--- a/src/tests/eosjs-jssig.test.ts
+++ b/src/tests/eosjs-jssig.test.ts
@@ -44,80 +44,73 @@ describe('JsSignatureProvider', () => {
     ];
 
     // These are simplified tests simply to verify a refactor didn't mess with existing code
-
-    it('builds public keys from private when constructed', async () => {
-        const provider = new JsSignatureProvider(privateKeys);
-        const actualPublicKeys = await provider.getAvailableKeys();
-        expect(actualPublicKeys).toEqual(k1FormatPublicKeys);
-    });
-
-    it('builds p256 elliptic public keys from private when constructed', async () => {
-        const provider = new JsSignatureProvider(privateKeysR1);
-        const actualPublicKeys = await provider.getAvailableKeys();
-        expect(actualPublicKeys).toEqual(r1FormatPublicKeys);
-    });
-
-    it('signs a transaction', async () => {
-        const provider = new JsSignatureProvider(privateKeys);
-        const chainId = '12345';
-        const requiredKeys = k1FormatPublicKeys;
-        const serializedTransaction = new Uint8Array([
-            0, 16, 32, 128, 255,
-        ]);
-
-        const signOutput = await provider.sign(
-            { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
-        );
-
-        expect(signOutput).toEqual({
-            signatures: expect.any(Array),
-            serializedTransaction,
-            serializedContextFreeData: undefined
-        });
-    });
-
-    it('confirm elliptic conversion functions are actually reciprocal', async () => {
-        const provider = new JsSignatureProvider(privateKeys);
-        const chainId = '12345';
-        const requiredKeys = k1FormatPublicKeys;
-        const serializedTransaction = new Uint8Array([
-            0, 16, 32, 128, 255,
-        ]);
-
-        const signOutput = await provider.sign(
-            { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
-        );
-
-        const sig: Signature = Signature.fromString(signOutput.signatures[0]);
-        const ellipticSig: ec.Signature = sig.toElliptic();
-        const eosSig = Signature.fromElliptic(ellipticSig, KeyType.k1);
-        expect(sig).toEqual(eosSig);
-    });
-
-    it('verify a transaction', async () => {
-        const provider = new JsSignatureProvider([privateKeys[0]]);
-        const chainId = '12345';
-        const requiredKeys = [k1FormatPublicKeys[0]];
-        const serializedTransaction = new Uint8Array([
-            0, 16, 32, 128, 255,
-        ]);
-
-        const signOutput = await provider.sign(
-            { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
-        );
-
-        const EC = new ec('secp256k1');
-        const ellipticSig = Signature.fromString(signOutput.signatures[0]).toElliptic();
-        expect(
-            EC.verify(
-                digestFromSerializedData(chainId, serializedTransaction),
-                ellipticSig,
-                PrivateKey.fromString(privateKeys[0]).toElliptic()
-            )
-        ).toEqual(true);
-    });
-
     describe('secp256k1 elliptic', () => {
+        it('builds public keys from private when constructed', async () => {
+            const provider = new JsSignatureProvider(privateKeys);
+            const actualPublicKeys = await provider.getAvailableKeys();
+            expect(actualPublicKeys).toEqual(k1FormatPublicKeys);
+        });
+
+        it('signs a transaction', async () => {
+            const provider = new JsSignatureProvider(privateKeys);
+            const chainId = '12345';
+            const requiredKeys = k1FormatPublicKeys;
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            expect(signOutput).toEqual({
+                signatures: expect.any(Array),
+                serializedTransaction,
+                serializedContextFreeData: undefined
+            });
+        });
+
+        it('confirm elliptic conversion functions are actually reciprocal', async () => {
+            const provider = new JsSignatureProvider(privateKeys);
+            const chainId = '12345';
+            const requiredKeys = k1FormatPublicKeys;
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            const sig: Signature = Signature.fromString(signOutput.signatures[0]);
+            const ellipticSig: ec.Signature = sig.toElliptic();
+            const eosSig = Signature.fromElliptic(ellipticSig, KeyType.k1);
+            expect(sig).toEqual(eosSig);
+        });
+
+        it('verify a transaction', async () => {
+            const provider = new JsSignatureProvider([privateKeys[0]]);
+            const chainId = '12345';
+            const requiredKeys = [k1FormatPublicKeys[0]];
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            const EC = new ec('secp256k1');
+            const ellipticSig = Signature.fromString(signOutput.signatures[0]).toElliptic();
+            expect(
+                EC.verify(
+                    digestFromSerializedData(chainId, serializedTransaction),
+                    ellipticSig,
+                    PrivateKey.fromString(privateKeys[0]).toElliptic()
+                )
+            ).toEqual(true);
+        });
+
         it('ensure public key functions are actual inverses of each other', async () => {
             const eosioPubKey = PublicKey.fromString(k1FormatPublicKeys[0]);
             const ellipticPubKey = eosioPubKey.toElliptic();
@@ -167,6 +160,72 @@ describe('JsSignatureProvider', () => {
     });
 
     describe('p256 elliptic', () => {
+        it('builds public keys from private when constructed', async () => {
+            const provider = new JsSignatureProvider(privateKeysR1);
+            const actualPublicKeys = await provider.getAvailableKeys();
+            expect(actualPublicKeys).toEqual(r1FormatPublicKeys);
+        });
+
+        it('signs a transaction', async () => {
+            const provider = new JsSignatureProvider(privateKeysR1);
+            const chainId = '12345';
+            const requiredKeys = r1FormatPublicKeys;
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            expect(signOutput).toEqual({
+                signatures: expect.any(Array),
+                serializedTransaction,
+                serializedContextFreeData: undefined
+            });
+        });
+
+        it('confirm elliptic conversion functions are actually reciprocal', async () => {
+            const provider = new JsSignatureProvider(privateKeysR1);
+            const chainId = '12345';
+            const requiredKeys = r1FormatPublicKeys;
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            const sig: Signature = Signature.fromString(signOutput.signatures[0]);
+            const ellipticSig: ec.Signature = sig.toElliptic();
+            const eosSig = Signature.fromElliptic(ellipticSig, KeyType.r1);
+            expect(sig).toEqual(eosSig);
+        });
+
+        it('verify a transaction', async () => {
+            const provider = new JsSignatureProvider([privateKeysR1[0]]);
+            const chainId = '12345';
+            const requiredKeys = [r1FormatPublicKeys[0]];
+            const serializedTransaction = new Uint8Array([
+                0, 16, 32, 128, 255,
+            ]);
+
+            const signOutput = await provider.sign(
+                { chainId, requiredKeys, serializedTransaction } as SignatureProviderArgs
+            );
+
+            const EC = new ec('p256');
+            const ellipticSig = Signature.fromString(signOutput.signatures[0]).toElliptic();
+            expect(
+                EC.verify(
+                    digestFromSerializedData(chainId, serializedTransaction),
+                    ellipticSig,
+                    PrivateKey.fromString(privateKeysR1[0]).toElliptic()
+                )
+            ).toEqual(true);
+        });
+
         it('ensure public key functions using p256 format are actual inverses of each other', async () => {
             const eosioPubKey = PublicKey.fromString(r1FormatPublicKeys[0]);
             const ellipticPubKey = eosioPubKey.toElliptic();


### PR DESCRIPTION
## Change Description
Adjusting the existing PrivateKey, PublicKey, Signature, and JsSignatureProvider to use p256 r1 format keys if optional arguments are provided, such as the r1 KeyType from numeric and elliptic constructed with p256.  K1 format and secp256k1 are default if no ecurve/keyType are provided.


## API Changes
- [x] API Changes
PrivateKey.getType() => returns private variable this.key.type
PublicKey.getType() => returns private variable this.key.type
Signature.getType() => returns private variable this.signature.type

## Documentation Additions
- [ ] Documentation Additions
