### PR TITLE
Removing the latest deploy from .travis.yml (release/21.0.x branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ deploy:
       - ./scripts/publish-edge.sh
     on: 
       branch: develop
-  - provider: script
-    skip_cleanup: true
-    script: 
-      - ./scripts/publish-tag.sh $PUBLISH_NPM_LATEST_FROM
-    on: 
-      tags: true
-      condition: $TRAVIS_IS_LATEST_TAG = true # sourced from ./scripts/is_latest.sh
 notifications:
   webhooks:
     secure: bBIpgJmtb4WbXgGTD71INlC7LqscHKOWZMiBmRtkUD1X9fjNzgNVKsjf4ZlTWpq9YtKFox0bAWjS00feRYlHZZal5tZEt9wRKJbkZEgnCa32YF2YOng0Q5JxoIBskH0SSUf/qocwjPmYQu+2Y3Y9KoLoV2C72qedGgSrrMmLWSVPA91tyqPl4gOU0HS6/9KU1QNf7Uv0v7Fo10+V+JwQC03MoC2+1dkz799LuUr2SmmN3JuLWSXl9KIq7CCF7wkcqzq1vMk176mmEH1/26InNXKLXIW/MqIjMfkZq4j+IjW+JbuWz/Qh3EY+rbQAMT+++tIYHNsh2wZppvAAPjf4vqO3m9Q4WBB2KbL6EDvE/ySDURxLzZl618u8WUbJh2o61k0R0rxPPl6yFdkl9jXV48IVTHEDYHkgghtLSSENMUmjK8kshA2qreG79Mj2l2jicZ5Vn7jv4iORQHS0PUXg4ouds+5dY0SPm9aLIop6f9WD0mcQFP9mEfagWA6EnGUxTPFQDQmNVGkpZk2afYNAT4LbOd8wrqDTsNWXRvA3QLLOiqBbhajY17Fvrh24ecJ79TERABLscFkYtke8Xx2K/lKg/T10TZuaL9VbTg4rKrD+59OTZev6JlNdGG8FR31SuJK8Ds3zmiyojCoCay54BDUbmZ0STJ1/6ocUvFka0YE=


### PR DESCRIPTION
## Change Description
Travis CI configuration would push any tagged branch to latest on npm, which recently affected the tagged release/21.0.x branch that was intended to be an RC and not the latest on npm.  Removing the configuration while the process is reworked.

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
