### PR TITLE
Zero padding Signature r-value/s-value to 32 bytes

### DIFF
--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -24,8 +24,8 @@ export class Signature {
 
     /** Instantiate Signature from an `elliptic`-format Signature */
     public static fromElliptic(ellipticSig: EC.Signature, keyType: KeyType, ec?: EC): Signature {
-        const r = ellipticSig.r.toArray();
-        const s = ellipticSig.s.toArray();
+        const r = ellipticSig.r.toArray('be', 32);
+        const s = ellipticSig.s.toArray('be', 32);
         let eosioRecoveryParam;
         if (keyType === KeyType.k1) {
             eosioRecoveryParam = ellipticSig.recoveryParam + 27;


### PR DESCRIPTION
## Change Description
With the current v21 release candidate, signatures that have less than 32 byte r or s values will generate signatures with lengths less than the 65 bytes necessary.  The r and s need to be zero padded to resolve this issue.  The elliptic library uses bn.js for the r and s values and the .toArray operation has a length argument with the purpose of zero padding the value to the length.

Fixes #663 

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
