### PR TITLE
Minified file convention (release/21.0.x branch)

### DIFF
--- a/docs/basic-usage/00_browser.md
+++ b/docs/basic-usage/00_browser.md
@@ -2,9 +2,9 @@ To use `eosjs` in a browser run `npm run build-web` or `yarn build-web`.  This w
 ```html
 <pre style="width: 100%; height: 100%; margin:0px; "></pre>
 
-<script src='dist-web/eosjs-api.js'></script>
-<script src='dist-web/eosjs-jsonrpc.js'></script>
-<script src='dist-web/eosjs-jssig.js'></script>
+<script src='dist-web/eosjs-api.min.js'></script>
+<script src='dist-web/eosjs-jsonrpc.min.js'></script>
+<script src='dist-web/eosjs-jssig.min.js'></script>
 ```
 
 To cache ABIs and reduce network usage, reuse the `api` object for all transactions.  This implies you should only call `new eosjs_api.Api(...)` once.
@@ -48,7 +48,7 @@ To cache ABIs and reduce network usage, reuse the `api` object for all transacti
 ```
 
 ## Debugging
-If you would like readable source files for debugging, change the file reference to the `-debug.js` files inside `dist-web/debug` directory.  These files should only be used for development as they are over 10 times as large as the minified versions, and importing the debug versions will increase loading times for the end user.
+If you would like readable source files for debugging, change the file reference to the `.js` files inside `dist-web` directory.  These files should only be used for development as they are over 10 times as large as the minified versions, and importing the debug versions will increase loading times for the end user.
 
 ## IE11 and Edge Support
 If you need to support IE11 or Edge you will also need to install a text-encoding polyfill, as eosjs Signing is dependent on the TextEncoder which IE11 and Edge do not provide.  Pass the TextEncoder and TextDecoder to the API constructor as demonstrated in the [CommonJS example](01_commonjs.md).  Refer to the documentation [here](https://github.com/inexorabletash/text-encoding) to determine the best way to include it in your project.

--- a/src/tests/web.html
+++ b/src/tests/web.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <link rel='stylesheet' type='text/css' href='web.css'>
-        <script src='../../dist-web/eosjs-api.js'></script>
-        <script src='../../dist-web/eosjs-jsonrpc.js'></script>
-        <script src='../../dist-web/eosjs-jssig.js'></script>
+        <script src='../../dist-web/eosjs-api.min.js'></script>
+        <script src='../../dist-web/eosjs-jsonrpc.min.js'></script>
+        <script src='../../dist-web/eosjs-jssig.min.js'></script>
         <script>
             const privateKey = '5JuH9fCXmU3xbj8nRmhPZaVrxxXrdPaRmZLW1cznNTmTQR2Kg5Z'; // replace with 'bob' account private key
             /* new accounts for testing can be created by unlocking a cleos wallet then calling: 

--- a/webpack.debug.js
+++ b/webpack.debug.js
@@ -27,8 +27,8 @@ module.exports = {
         extensions: ['.tsx', '.ts', '.js']
     },
     output: {
-        filename: x => x.chunk.name.replace('_', '-') + '-debug.js',
+        filename: x => x.chunk.name.replace('_', '-') + '.js',
         library: '[name]',
-        path: path.resolve(__dirname, 'dist-web', 'debug'),
+        path: path.resolve(__dirname, 'dist-web'),
     }
 };

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -26,7 +26,7 @@ module.exports = {
         extensions: ['.tsx', '.ts', '.js']
     },
     output: {
-        filename: x => x.chunk.name.replace('_', '-') + '.js',
+        filename: x => x.chunk.name.replace('_', '-') + '.min.js',
         library: '[name]',
         path: path.resolve(__dirname, 'dist-web'),
     }


### PR DESCRIPTION
## Change Description
Adjusting the minified and debug files generated by `yarn build-web` to follow minified file convention (*.min.js) to create easier understanding which files should be used in development/production.

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
Adjusted the browser usage documentation to the new file convention
