### PR TITLE
Added false for shouldHash to sign() usages (release/21.0.x branch)

### DIFF
--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -69,7 +69,7 @@ class JsSignatureProvider implements SignatureProvider {
             const publicKey = PublicKey.fromString(key);
             const ellipticPrivateKey = this.keys.get(convertLegacyPublicKey(key));
             const privateKey = PrivateKey.fromElliptic(ellipticPrivateKey, publicKey.getType());
-            const signature = privateKey.sign(digest);
+            const signature = privateKey.sign(digest, false);
             signatures.push(signature.toString());
         }
 

--- a/src/tests/eosjs-jssig.test.ts
+++ b/src/tests/eosjs-jssig.test.ts
@@ -126,7 +126,8 @@ describe('JsSignatureProvider', () => {
             expect(
                 signature.verify(
                     digestFromSerializedData(chainId, serializedTransaction),
-                    PublicKey.fromString(k1FormatPublicKeys[0])
+                    PublicKey.fromString(k1FormatPublicKeys[0]),
+                    false
                 )
             ).toEqual(true);
         });
@@ -289,7 +290,8 @@ describe('JsSignatureProvider', () => {
             expect(
                 signature.verify(
                     digestFromSerializedData(chainId, serializedTransaction),
-                    PublicKey.fromString(r1FormatPublicKeys[0])
+                    PublicKey.fromString(r1FormatPublicKeys[0]),
+                    false
                 )
             ).toEqual(true);
         });


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
PrivateKey.sign() was changed to hash the data by default without shouldHash set to false, JsSignatureProvider code was not changed to accommodate.

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
