### PR TITLE
Resolving deprecation of new Buffer() (release/21.0.x branch)

### DIFF
--- a/src/PublicKey.ts
+++ b/src/PublicKey.ts
@@ -47,7 +47,7 @@ export class PublicKey {
     /** Export public key as `elliptic`-format public key */
     public toElliptic(): EC.KeyPair {
         return this.ec.keyPair({
-            pub: new Buffer(this.key.data),
+            pub: Buffer.from(this.key.data),
         });
     }
 

--- a/src/eosjs-jssig.ts
+++ b/src/eosjs-jssig.ts
@@ -23,9 +23,9 @@ function digestFromSerializedData(
     serializedContextFreeData?: Uint8Array,
     e = defaultEc) {
     const signBuf = Buffer.concat([
-        new Buffer(chainId, 'hex'),
-        new Buffer(serializedTransaction),
-        new Buffer(
+        Buffer.from(chainId, 'hex'),
+        Buffer.from(serializedTransaction),
+        Buffer.from(
             serializedContextFreeData ?
                 new Uint8Array(e.hash().update(serializedContextFreeData).digest()) :
                 new Uint8Array(32)


### PR DESCRIPTION
## Change Description
`The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.`

Resolved by switching usages to `Buffer.from()`

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
