### PR TITLE
Adding an alternative option for browser to generate key pairs (release/21.0.x branch)

### DIFF
--- a/src/eosjs-ecc-migration.ts
+++ b/src/eosjs-ecc-migration.ts
@@ -1,17 +1,20 @@
 import {PrivateKey, PublicKey, Signature} from './eosjs-jssig';
 import {generateKeyPair} from './eosjs-key-conversions';
 import {KeyType} from './eosjs-numeric';
+import {ec as EC} from 'elliptic';
 
 export const ecc = {
     initialize: () => console.error('Method deprecated'),
     unsafeRandomKey: () => console.error('Method deprecated'),
-    randomKey: (cpuEntropyBits?: number): Promise<string> => {
+    randomKey: (
+        cpuEntropyBits?: number, options: { secureEnv?: boolean, ecOptions?: EC.GenKeyPairOptions } = {}
+        ): Promise<string> => {
         if (cpuEntropyBits !== undefined) {
             console.warn('Argument `cpuEntropyBits` is deprecated, ' +
                 'use the options argument instead');
         }
 
-        const { privateKey } = generateKeyPair(KeyType.k1);
+        const { privateKey } = generateKeyPair(KeyType.k1, options);
         return Promise.resolve(privateKey.toLegacyString());
     },
     seedPrivate: () => console.error('Method deprecated'),

--- a/src/eosjs-key-conversions.ts
+++ b/src/eosjs-key-conversions.ts
@@ -22,8 +22,8 @@ export const generateKeyPair = (type: KeyType, options?: EC.GenKeyPairOptions):
     if (process.env.EOSJS_KEYGEN_ALLOWED !== 'true' && window.EOSJS_KEYGEN_ALLOWED !== 'true') {
         throw new Error('Key generation is completely INSECURE in production environments in the browser. ' +
             'If you are absolutely certain this does NOT describe your environment, add an environment variable ' +
-            '`EOSJS_KEYGEN_ALLOWED` set to \'true\'.  If this does describe your environment and you add the ' +
-            'environment variable, YOU DO SO AT YOUR OWN RISK AND THE RISK OF YOUR USERS.');
+            'or window variable `EOSJS_KEYGEN_ALLOWED` set to \'true\'.  If this does describe your environment ' +
+            'and you add the environment/window variable, YOU DO SO AT YOUR OWN RISK AND THE RISK OF YOUR USERS.');
     }
     let ec;
     if (type === KeyType.k1) {

--- a/src/eosjs-key-conversions.ts
+++ b/src/eosjs-key-conversions.ts
@@ -18,7 +18,8 @@ export const constructElliptic = (type: KeyType): EC => {
 
 export const generateKeyPair = (type: KeyType, options?: EC.GenKeyPairOptions):
     {publicKey: PublicKey, privateKey: PrivateKey} => {
-    if (process.env.EOSJS_KEYGEN_ALLOWED !== 'true') {
+    // @ts-ignore
+    if (process.env.EOSJS_KEYGEN_ALLOWED !== 'true' && window.EOSJS_KEYGEN_ALLOWED !== 'true') {
         throw new Error('Key generation is completely INSECURE in production environments in the browser. ' +
             'If you are absolutely certain this does NOT describe your environment, add an environment variable ' +
             '`EOSJS_KEYGEN_ALLOWED` set to \'true\'.  If this does describe your environment and you add the ' +

--- a/src/eosjs-key-conversions.ts
+++ b/src/eosjs-key-conversions.ts
@@ -16,14 +16,13 @@ export const constructElliptic = (type: KeyType): EC => {
     return new EC('p256') as any;
 };
 
-export const generateKeyPair = (type: KeyType, options?: EC.GenKeyPairOptions):
+export const generateKeyPair = (type: KeyType, options: { secureEnv?: boolean, ecOptions?: EC.GenKeyPairOptions } = {}):
     {publicKey: PublicKey, privateKey: PrivateKey} => {
-    // @ts-ignore
-    if (process.env.EOSJS_KEYGEN_ALLOWED !== 'true' && window.EOSJS_KEYGEN_ALLOWED !== 'true') {
+    if (!options.secureEnv) {
         throw new Error('Key generation is completely INSECURE in production environments in the browser. ' +
-            'If you are absolutely certain this does NOT describe your environment, add an environment variable ' +
-            'or window variable `EOSJS_KEYGEN_ALLOWED` set to \'true\'.  If this does describe your environment ' +
-            'and you add the environment/window variable, YOU DO SO AT YOUR OWN RISK AND THE RISK OF YOUR USERS.');
+            'If you are absolutely certain this does NOT describe your environment, set `secureEnv` in your ' +
+            'options to `true`.  If this does describe your environment and you set `secureEnv` to `true`, ' +
+            'YOU DO SO AT YOUR OWN RISK AND THE RISK OF YOUR USERS.');
     }
     let ec;
     if (type === KeyType.k1) {
@@ -31,7 +30,7 @@ export const generateKeyPair = (type: KeyType, options?: EC.GenKeyPairOptions):
     } else {
         ec = new EC('p256') as any;
     }
-    const ellipticKeyPair = ec.genKeyPair(options);
+    const ellipticKeyPair = ec.genKeyPair(options.ecOptions);
     const publicKey = PublicKey.fromElliptic(ellipticKeyPair, type, ec);
     const privateKey = PrivateKey.fromElliptic(ellipticKeyPair, type, ec);
     return {publicKey, privateKey};

--- a/src/tests/eosjs-ecc-migration.test.ts
+++ b/src/tests/eosjs-ecc-migration.test.ts
@@ -28,9 +28,8 @@ describe('ecc Migration', () => {
     });
 
     it('verifies `randomKey` calls generateKeyPair', async () => {
-        process.env.EOSJS_KEYGEN_ALLOWED = 'true';
         console.warn = jest.fn();
-        const privateKey = await eccMigration.randomKey(0);
+        const privateKey = await eccMigration.randomKey(0, { secureEnv: true });
         expect(console.warn).toHaveBeenCalledWith('Argument `cpuEntropyBits` is deprecated, ' +
             'use the options argument instead');
         expect(typeof privateKey).toEqual('string');

--- a/src/tests/eosjs-jssig.test.ts
+++ b/src/tests/eosjs-jssig.test.ts
@@ -48,16 +48,14 @@ describe('JsSignatureProvider', () => {
     // These are simplified tests simply to verify a refactor didn't mess with existing code
     describe('secp256k1 elliptic', () => {
         it('generates a private and public key pair', () => {
-            process.env.EOSJS_KEYGEN_ALLOWED = 'true';
-            const {privateKey, publicKey} = generateKeyPair(KeyType.k1);
+            const {privateKey, publicKey} = generateKeyPair(KeyType.k1, { secureEnv: true });
             expect(privateKey).toBeInstanceOf(PrivateKey);
             expect(privateKey.isValid()).toBeTruthy();
             expect(publicKey).toBeInstanceOf(PublicKey);
             expect(publicKey.isValid()).toBeTruthy();
         });
 
-        it('throws error with no EOSJS_KEYGEN_ALLOWED environment variable', () => {
-            process.env.EOSJS_KEYGEN_ALLOWED = null;
+        it('throws error with no options.secureEnv variable', () => {
             expect(() => generateKeyPair(KeyType.k1)).toThrowError();
         });
 
@@ -202,16 +200,14 @@ describe('JsSignatureProvider', () => {
 
     describe('p256 elliptic', () => {
         it('generates a private and public key pair', () => {
-            process.env.EOSJS_KEYGEN_ALLOWED = 'true';
-            const {privateKey, publicKey} = generateKeyPair(KeyType.r1);
+            const {privateKey, publicKey} = generateKeyPair(KeyType.r1, { secureEnv: true });
             expect(privateKey).toBeInstanceOf(PrivateKey);
             expect(privateKey.isValid()).toBeTruthy();
             expect(publicKey).toBeInstanceOf(PublicKey);
             expect(publicKey.isValid()).toBeTruthy();
         });
 
-        it('throws error with no EOSJS_KEYGEN_ALLOWED environment variable', () => {
-            process.env.EOSJS_KEYGEN_ALLOWED = null;
+        it('throws error with no options.secureEnv variable', () => {
             expect(() => generateKeyPair(KeyType.r1)).toThrowError();
         });
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
eosjs has a "browser usage" option in the documentation that means building the files with `build-web` and serving those files in the html.  Unfortunately, without webpack or nodejs, that means that it's impossible to set a `process.env` environment variable.  Another alternative option is needed to allow users to run the `generateKeyPair` method.  Code required a `// @ts-ignore` due to TS2339.

It is worth noting that running this command in the browser is unsafe in production environments but developers will likely need this option for development or testing as well.

Resolves https://github.com/EOSIO/eosjs/issues/737

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
