### PR TITLE
Updating CI/CD to check for protected branch and use token so workflow re-runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,24 +45,20 @@ jobs:
         uses: cypress-io/github-action@8aac1d019734a107e4eaaefe2e26beb3149e5540
         with:
           spec: cypress/integration/index.spec.js
-      - name: Commit
+      - name: Get Protected Status
         if: ${{ github.event_name == 'push' }}
+        id: protected_step
+        run: |
+          PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
+          echo ::set-output name=protected::$PROTECTED
+      - name: Commit/Push
+        if: ${{ github.event_name == 'push' && steps.protected_step.outputs.protected == 'false' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
-      - name: Get Branch Name
-        if: ${{ github.event_name == 'push' }}
-        id: branch_name
-        run: |
-          echo ::set-output name=short_ref::${GITHUB_REF#refs/*/}
-      - name: Push
-        if: ${{ github.event_name == 'push' }}
-        uses: ad-m/github-push-action@68af9897f2b021035ca3952bf354bbb4675c1762
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.branch_name.outputs.short_ref }}
-
+          git remote set-url origin https://x-access-token:${{ secrets.GIT_API_KEY }}@github.com/${{ github.repository }}
+          git push origin ${GITHUB_REF#refs/*/}
     services:
       nodeos:
         image: eosio/eosjs-ci:v0.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,21 @@ jobs:
       matrix:
         node-version: [12.14.1]
     steps:
-      - name: Checkout
+      - name: Check for GIT_API_KEY
+        id: check_token
+        run: echo ::set-output name=token_exists::${HAS_SECRET}
+        env:
+          HAS_SECRET: ${{ secrets.GIT_API_KEY != null }}
+      - name: Checkout (with GIT_API_KEY)
+        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'true' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
-          token: ${{ secrets.GIT_API_TOKEN }}
+          token: ${{ secrets.GIT_API_KEY }}
+      - name: Checkout (with GitHub Token)
+        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'false' }}
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          token: ${{ github.token }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@1c5c1375b3817ad821719597effe8e3d6f764930
         with:
@@ -48,16 +59,16 @@ jobs:
         with:
           spec: cypress/integration/index.spec.js
       - name: Get Protected Status
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push'
         id: protected_step
         run: |
           PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
           echo ::set-output name=protected::$PROTECTED
       - name: Commit/Push
-        if: ${{ github.event_name == 'push' && steps.protected_step.outputs.protected == 'false' }}
+        if: github.event_name == 'push' && steps.protected_step.outputs.protected == 'false'
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --global user.name 'Block.one DevOps'
+          git config --global user.email 'blockone-devops@users.noreply.github.com'
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
           git push origin ${GITHUB_REF#refs/*/}
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         env:
           HAS_SECRET: ${{ secrets.GIT_API_KEY != null }}
       - name: Checkout (with GIT_API_KEY)
-        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'true' }}
+        if: ${{ steps.check_token.outputs.token_exists == 'true' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
           token: ${{ secrets.GIT_API_KEY }}
       - name: Checkout (with GitHub Token)
-        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'false' }}
+        if: ${{ steps.check_token.outputs.token_exists == 'false' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
           token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          token: ${{ secrets.GIT_API_TOKEN }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@1c5c1375b3817ad821719597effe8e3d6f764930
         with:
@@ -57,7 +59,6 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
-          git remote set-url origin https://x-access-token:${{ secrets.GIT_API_KEY }}@github.com/${{ github.repository }}
           git push origin ${GITHUB_REF#refs/*/}
     services:
       nodeos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name == 'push'
         id: protected_step
         run: |
-          PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
+          PROTECTED=$(curl "https://api.github.com/repos/${{ github.repository }}/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
           echo ::set-output name=protected::$PROTECTED
       - name: Commit/Push
         if: github.event_name == 'push' && steps.protected_step.outputs.protected == 'false'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eosjs
-[![Build Status](https://travis-ci.org/EOSIO/eosjs.svg?branch=master)](https://travis-ci.org/EOSIO/eosjs)  [![npm version](https://badge.fury.io/js/eosjs.svg)](https://badge.fury.io/js/eosjs)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  ![npm](https://img.shields.io/npm/dw/eosjs.svg)
+[![Build Status](https://github.com/eosio/eosjs/workflows/CI/badge.svg?branch=master)](https://github.com/EOSIO/eosjs/actions)  [![npm version](https://badge.fury.io/js/eosjs.svg)](https://badge.fury.io/js/eosjs)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  ![npm](https://img.shields.io/npm/dw/eosjs.svg)
 
 Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](https://developers.eos.io/eosio-nodeos/reference).
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@blockone/eslint-config-blockone": "^3.0.0",
     "@types/elliptic": "^6.4.12",
     "@types/jest": "^25.2.3",
-    "@types/node": "^14.0.12",
+    "@types/node": "^14.0.13",
     "@types/pako": "^1.0.1",
     "cypress": "^4.8.0",
     "eosjs-ecc": "^4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,9 +606,9 @@
     "@types/node" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz#79d7a78bad4219f4c03d6557a1c72d9ca6ba62d5"
-  integrity sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
 "@types/istanbul-lib-report@*":
   version "3.0.0"
@@ -634,14 +634,14 @@
     pretty-format "^25.2.1"
 
 "@types/json-schema@^7.0.3":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
-  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/node@*", "@types/node@^14.0.12":
-  version "14.0.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.12.tgz#9c1d8ffb8084e8936603a6122a7649e40e68e04b"
-  integrity sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q==
+"@types/node@*", "@types/node@^14.0.13":
+  version "14.0.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
+  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -912,9 +912,9 @@ acorn@^6.4.1:
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -1531,9 +1531,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
When merging with protected branches, the yarn.lock updates will fail to push.  This will check if the branch is protected and avoid pushing and failing.

Additionally, the workflow needs to re-run and succeed in order to easily merge.  However, the `github.token` supplied to GitHub Actions will not re-run a workflow if it fires the event to avoid infinite runs of the workflow.  Adding and using a different token will allow the workflow to re-run.  Infinite runs is not an issue for this workflow since it only runs again if there are any updates to the dependencies.

Since forks wouldn't have the token set in their repo secrets but all repos have `github.token` set inside workflows, it was also important to create a conditional that allows the workflow to checkout with either token so workflows ran in forks won't fail without the token in the repo secrets.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
