### PR TITLE
Updating CI/CD to check for protected branch and use token so workflow re-runs (release/21.0.x branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,24 +45,20 @@ jobs:
         uses: cypress-io/github-action@8aac1d019734a107e4eaaefe2e26beb3149e5540
         with:
           spec: cypress/integration/index.spec.js
-      - name: Commit
+      - name: Get Protected Status
         if: ${{ github.event_name == 'push' }}
+        id: protected_step
+        run: |
+          PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
+          echo ::set-output name=protected::$PROTECTED
+      - name: Commit/Push
+        if: ${{ github.event_name == 'push' && steps.protected_step.outputs.protected == 'false' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
-      - name: Get Branch Name
-        if: ${{ github.event_name == 'push' }}
-        id: branch_name
-        run: |
-          echo ::set-output name=short_ref::${GITHUB_REF#refs/*/}
-      - name: Push
-        if: ${{ github.event_name == 'push' }}
-        uses: ad-m/github-push-action@68af9897f2b021035ca3952bf354bbb4675c1762
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ steps.branch_name.outputs.short_ref }}
-
+          git remote set-url origin https://x-access-token:${{ secrets.GIT_API_KEY }}@github.com/${{ github.repository }}
+          git push origin ${GITHUB_REF#refs/*/}
     services:
       nodeos:
         image: eosio/eosjs-ci:v0.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,21 @@ jobs:
       matrix:
         node-version: [12.14.1]
     steps:
-      - name: Checkout
+      - name: Check for GIT_API_KEY
+        id: check_token
+        run: echo ::set-output name=token_exists::${HAS_SECRET}
+        env:
+          HAS_SECRET: ${{ secrets.GIT_API_KEY != null }}
+      - name: Checkout (with GIT_API_KEY)
+        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'true' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
-          token: ${{ secrets.GIT_API_TOKEN }}
+          token: ${{ secrets.GIT_API_KEY }}
+      - name: Checkout (with GitHub Token)
+        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'false' }}
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          token: ${{ github.token }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@1c5c1375b3817ad821719597effe8e3d6f764930
         with:
@@ -48,16 +59,16 @@ jobs:
         with:
           spec: cypress/integration/index.spec.js
       - name: Get Protected Status
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push'
         id: protected_step
         run: |
           PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
           echo ::set-output name=protected::$PROTECTED
       - name: Commit/Push
-        if: ${{ github.event_name == 'push' && steps.protected_step.outputs.protected == 'false' }}
+        if: github.event_name == 'push' && steps.protected_step.outputs.protected == 'false'
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --global user.name 'Block.one DevOps'
+          git config --global user.email 'blockone-devops@users.noreply.github.com'
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
           git push origin ${GITHUB_REF#refs/*/}
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         env:
           HAS_SECRET: ${{ secrets.GIT_API_KEY != null }}
       - name: Checkout (with GIT_API_KEY)
-        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'true' }}
+        if: ${{ steps.check_token.outputs.token_exists == 'true' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
           token: ${{ secrets.GIT_API_KEY }}
       - name: Checkout (with GitHub Token)
-        if: ${{ github.event_name == 'push' && steps.check_token.outputs.token_exists == 'false' }}
+        if: ${{ steps.check_token.outputs.token_exists == 'false' }}
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
         with:
           token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          token: ${{ secrets.GIT_API_TOKEN }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@1c5c1375b3817ad821719597effe8e3d6f764930
         with:
@@ -57,7 +59,6 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit package.json yarn.lock -m "Updating package.json and yarn.lock" || echo "Nothing to commit"
-          git remote set-url origin https://x-access-token:${{ secrets.GIT_API_KEY }}@github.com/${{ github.repository }}
           git push origin ${GITHUB_REF#refs/*/}
     services:
       nodeos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name == 'push'
         id: protected_step
         run: |
-          PROTECTED=$(curl "https://api.github.com/repos/bradlhart/eosjs/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
+          PROTECTED=$(curl "https://api.github.com/repos/${{ github.repository }}/branches/${GITHUB_REF#refs/*/}" 2>/dev/null | jq -r '.protected')
           echo ::set-output name=protected::$PROTECTED
       - name: Commit/Push
         if: github.event_name == 'push' && steps.protected_step.outputs.protected == 'false'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eosjs
-[![Build Status](https://travis-ci.org/EOSIO/eosjs.svg?branch=master)](https://travis-ci.org/EOSIO/eosjs)  [![npm version](https://badge.fury.io/js/eosjs.svg)](https://badge.fury.io/js/eosjs)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  ![npm](https://img.shields.io/npm/dw/eosjs.svg)
+[![Build Status](https://github.com/eosio/eosjs/workflows/CI/badge.svg?branch=master)](https://github.com/EOSIO/eosjs/actions)  [![npm version](https://badge.fury.io/js/eosjs.svg)](https://badge.fury.io/js/eosjs)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  ![npm](https://img.shields.io/npm/dw/eosjs.svg)
 
 Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](https://developers.eos.io/eosio-nodeos/reference).
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,9 +912,9 @@ acorn@^6.4.1:
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 acorn@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 ajv-errors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
When merging with protected branches, the yarn.lock updates will fail to push.  This will check if the branch is protected and avoid pushing and failing.

Additionally, the workflow needs to re-run and succeed in order to easily merge.  However, the `github.token` supplied to GitHub Actions will not re-run a workflow if it fires the event to avoid infinite runs of the workflow.  Adding and using a different token will allow the workflow to re-run.  Infinite runs is not an issue for this workflow since it only runs again if there are any updates to the dependencies.

Since forks wouldn't have the token set in their repo secrets but all repos have `github.token` set inside workflows, it was also important to create a conditional that allows the workflow to checkout with either token so workflows ran in forks won't fail without the token in the repo secrets.

_Second PR to cherry pick commits to release/21.0.x branch_

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
