### PR TITLE
Allowing a name to be an empty string.

### DIFF
--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -320,7 +320,7 @@ export class SerialBuffer {
         if (typeof s !== 'string') {
             throw new Error('Expected string containing name');
         }
-        const regex = new RegExp(/^[.1-5a-z]{1,12}[.1-5a-j]?$/);
+        const regex = new RegExp(/^[.1-5a-z]{0,12}[.1-5a-j]?$/);
         if (!regex.test(s)) {
             throw new Error('Name should be less than 13 characters, or less than 14 if last character is between 1-5 or a-j, and only contain the following symbols .12345abcdefghijklmnopqrstuvwxyz'); // eslint-disable-line
         }

--- a/src/tests/eosjs-serialize.test.ts
+++ b/src/tests/eosjs-serialize.test.ts
@@ -114,13 +114,6 @@ describe('Serialize', () => {
             expect(serialBuffer.getName()).toEqual(expectedName);
         });
 
-        it('should not be able to push name with an account name too short', () => {
-            const name = '';
-
-            const shouldFail = () => serialBuffer.pushName(name);
-            expect(shouldFail).toThrowError(invalidNameErrorMessage);
-        });
-
         it('should not be able to push name with an account name too long', () => {
             const name = 'abcdabcdabcdab';
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
In order to update `owner` permission of an account the name of it's parent permission should be set to an empty string

Example:
```
{
    "account": "eosio",
    "name": "updateauth",
    "authorization": [{
        "actor": "someaccount"
        ",
        "permission": "owner"
    }],
    "data": {
        "account": "someaccount",
        "permission": "owner",
        "parent": "",
        "auth": {
            "threshold": 1,
            "keys": [{
                "key": "NEW_PUBLIC_KEY",
                "weight": 1
            }],
            "accounts": [],
            "waits": []
        }
    }
}
```

Current regex validation doesn't allow fields of `name` type to be an empty string. It causes a fail in serialisation of above mentioned action.
