### PR TITLE
Adding two pipelines for release branch for ci/cd (release 22.0.x)

### DIFF
--- a/.github/eosjs-ci/Dockerfile
+++ b/.github/eosjs-ci/Dockerfile
@@ -1,93 +1,51 @@
-### Current Version: v0.2.9
 ### Test:
 #### docker build --tag eosjs-ci:test ./.github/eosjs-ci
 #### docker run --publish 8888:8888 eosjs-ci:test
-### Deploy:
-#### docker build --tag eosio/eosjs-ci:v0.2.9 ./.github/eosjs-ci
-#### docker push eosio/eosjs-ci:v0.2.9
 
-FROM ubuntu:18.04
-ENTRYPOINT ["nodeos", "--data-dir", "/root/.local/share", "-e", "-p", "eosio", "--replay-blockchain", "--plugin", "eosio::producer_plugin", "--plugin", "eosio::chain_api_plugin", "--plugin", "eosio::trace_api_plugin", "--trace-no-abis", "--plugin", "eosio::db_size_api_plugin", "--plugin", "eosio::http_plugin", "--http-server-address=0.0.0.0:8888", "--access-control-allow-origin=*", "--contracts-console", "--http-validate-host=false", "--enable-account-queries=true", "--verbose-http-errors", "--max-transaction-time=100"]
-
-### base
-RUN yes | unminimize \
- && apt-get update \
- && apt-get install -yq \
-     binutils-gold \
-     build-essential \
-     clang-tools-8 \
-     curl \
-     g++-8 \
-     git \
-     libcurl4-gnutls-dev \
-     libgflags-dev \
-     libgmp3-dev \
-     libssl-dev \
-     libusb-1.0-0-dev \
-     lld-8 \
-     llvm-7 \
-     llvm-7-dev \
-     locales \
-     ninja-build \
-     pkg-config \
-     python \
-     software-properties-common \
-     wget \
-     xz-utils \
-     zlib1g-dev \
- && update-alternatives --remove-all cc \
- && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 100 \
- && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
- && update-alternatives --remove-all c++ \
- && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 100 \
- && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100 \
- && update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-8 100 \
- && locale-gen en_US.UTF-8 \
- && curl -sL https://deb.nodesource.com/setup_10.x | bash -
-
-ENV LANG=en_US.UTF-8
-
-### cmake
+ARG EOSBRANCH=develop
+ARG CDTBRANCH=develop
+FROM eosio/eosio.cdt:${CDTBRANCH} as contracts
 WORKDIR /root
-RUN curl -LO https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz \
- && tar -xzf cmake-3.13.2.tar.gz \
- && cd cmake-3.13.2 \
- && ./bootstrap --prefix=/usr/local --parallel=8 \
- && make -j8 \
- && make install \
- && cd /root \
- && rm -rf cmake-3.13.2.tar.gz cmake-3.13.2
+### base
+RUN apt-get update \
+ && apt-get install -yq curl git
 
-### boost
-RUN curl -LO https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 \
- && tar -xjf boost_1_72_0.tar.bz2 \
- && cd boost_1_72_0 \
- && ./bootstrap.sh --prefix=/usr/local \
- && ./b2 --with-iostreams --with-date_time --with-filesystem --with-system --with-program_options --with-chrono --with-test -j$(nproc) install \
- && cd /root \
- && rm -rf boost_1_72_0.tar.bz2 boost_1_72_0
-
-### libpq and libpqxx
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
- && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
- && apt-get update && apt-get -y install libpq-dev
-
-### eos
-RUN git clone https://github.com/EOSIO/eos.git \
+RUN git clone https://github.com/EOSIO/eos \
  && cd eos \
+ && git checkout develop
+
+RUN git clone https://github.com/EOSIO/eosio.contracts \
+ && cd eosio.contracts \
  && git checkout develop \
- && git submodule update --init --recursive \
+ && mkdir build && cd build && mkdir eosio.token && cd .. \
+ && eosio-cpp -abigen ./contracts/eosio.token/src/eosio.token.cpp -o ./build/eosio.token/eosio.token.wasm -R ./contracts/eosio.token/ricardian/ -I ./contracts/eosio.token/include/
+
+RUN git clone https://github.com/EOSIO/key-value-example-app.git \
+ && cd key-value-example-app \
+ && eosio-cpp -abigen ./contracts/kv_todo/src/kv_todo.cpp -o ./contracts/kv_todo/build/kv_todo.wasm -R ./contracts/kv_todo/ricardian/ -I ./contracts/kv_todo/include/
+
+RUN git clone https://github.com/EOSIO/return-values-example-app.git \
+ && cd return-values-example-app \
+ && eosio-cpp -abigen ./contracts/action_return_value/src/action_return_value.cpp -o ./contracts/action_return_value/build/action_return_value.wasm -R ./contracts/action_return_value/ricardian/
+
+RUN mkdir cfhello
+COPY ./contracts/cfhello.cpp /root/cfhello
+RUN cd cfhello \
  && mkdir build \
- && cd build \
- && CC=clang-8 CXX=clang++-8 cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_AR=/usr/bin/llvm-ar-8 -DCMAKE_RANLIB=/usr/bin/llvm-ranlib-8 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld .. \
- && CC=clang-8 CXX=clang++-8 ninja -j5 \
- && sudo ninja install \
- && sudo ln -s /usr/lib/x86_64-linux-gnu/cmake/eosio/ /usr/lib/cmake/eosio \
- && rm -rf /root/eos
+ && eosio-cpp -abigen ./cfhello.cpp -o ./build/cfhello.wasm
 
+
+FROM eosio/eos:${EOSBRANCH}
+ENTRYPOINT ["nodeos", "--data-dir", "/root/.local/share", "-e", "-p", "eosio", "--replay-blockchain", "--plugin", "eosio::producer_plugin", "--plugin", "eosio::chain_api_plugin", "--plugin", "eosio::trace_api_plugin", "--trace-no-abis", "--plugin", "eosio::db_size_api_plugin", "--plugin", "eosio::http_plugin", "--http-server-address=0.0.0.0:8888", "--access-control-allow-origin=*", "--contracts-console", "--http-validate-host=false", "--enable-account-queries=true", "--verbose-http-errors", "--max-transaction-time=100"]
+WORKDIR /root
 RUN mkdir -p "/opt/eosio/bin/contracts"
-
-COPY ./ /opt/eosio/bin
+COPY --from=contracts /root/eos/contracts/contracts/eosio.bios/bin/* /opt/eosio/bin/contracts/eosio.bios/
+COPY --from=contracts /root/eos/contracts/contracts/eosio.boot/bin/* /opt/eosio/bin/contracts/eosio.boot/
+COPY --from=contracts /root/eosio.contracts/build/ /opt/eosio/bin/contracts
+COPY --from=contracts /root/key-value-example-app/contracts/kv_todo/build/* /opt/eosio/bin/contracts/kv_todo/
+COPY --from=contracts /root/return-values-example-app/contracts/action_return_value/build/* /opt/eosio/bin/contracts/action_return_value/
+COPY --from=contracts /root/cfhello/build/* /opt/eosio/bin/contracts/cfhello/
+COPY ./ /opt/eosio/bin/
 
 RUN mkdir -p "/opt/eosio/bin/config-dir"
 RUN /bin/bash /opt/eosio/bin/scripts/deploy_contracts.sh

--- a/.github/eosjs-ci/contracts/cfhello.cpp
+++ b/.github/eosjs-ci/contracts/cfhello.cpp
@@ -1,0 +1,35 @@
+// Import necessary libraries
+#include <eosio/eosio.hpp>
+#include <eosio/transaction.hpp>
+
+using namespace eosio;
+
+class [[eosio::contract("cfhello")]] cfhello : public contract {
+  public:
+      using contract::contract;
+
+      [[eosio::action]]
+      void contextfree() {
+        int cfd_index = 0;
+        while(true) {
+          int read_size = get_context_free_data( cfd_index, nullptr, 0 );
+          if (read_size == -1) {
+            if (cfd_index == 0) {
+              print("No context free data found");
+            }
+            break;
+          }
+
+          char* context_free_data = new char[read_size];
+          get_context_free_data( cfd_index, context_free_data, read_size );
+
+          print("CFD ", std::to_string(cfd_index), ":", context_free_data, "\n");
+          cfd_index++;
+        }
+      }
+
+      [[eosio::action]]
+      void normal( name user ) {
+        print( "Hi, ", user);
+      }
+};

--- a/.github/eosjs-ci/scripts/deploy_contracts.sh
+++ b/.github/eosjs-ci/scripts/deploy_contracts.sh
@@ -203,14 +203,6 @@ cleos push action eosio setkvparams '[{"max_key_size":1024, "max_value_size":409
 cleos push action eosio setpparams '["01110000400100000000"]' -p eosio@active
 
 sleep 1s
-setabi eosio $CONTRACTS_DIR/eosio.system/eosio.system.abi
-setcode eosio $CONTRACTS_DIR/eosio.system/eosio.system.wasm
-
-sleep 1s
-setabi eosio.msig $CONTRACTS_DIR/eosio.msig/eosio.msig.abi
-setcode eosio.msig $CONTRACTS_DIR/eosio.msig/eosio.msig.wasm
-
-sleep 1s
 setabi cfhello $CONTRACTS_DIR/cfhello/cfhello.abi
 setcode cfhello $CONTRACTS_DIR/cfhello/cfhello.wasm
 
@@ -236,8 +228,6 @@ cleos push action eosio.token transfer '["bob", "alicer1", "1000000.0000 SYS", "
 cleos push action todo upsert '["bf581bee-9f2c-447b-94ad-78e4984b6f51", "todo", "Write Hello World Contract", false]' -p todo@active
 cleos push action todo upsert '["b7b0d09d-a82b-44d9-b067-3bae2d02917e", "todo", "Start Blockchain", false]' -p todo@active
 cleos push action todo upsert '["ac8acfe7-cd4e-4d22-8400-218b697a4517", "todo", "Deploy Hello World Contract", false]' -p todo@active
-
-cleos push action eosio init '[0, "4,SYS"]' -p eosio@active
 
 echo "All done initializing the blockchain"
 

--- a/.github/workflows/build-docker-develop.yml
+++ b/.github/workflows/build-docker-develop.yml
@@ -1,0 +1,34 @@
+name: Build Docker - Develop
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  build-docker:
+    name: Build Docker - Develop
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          ref: develop
+          token: ${{ github.token }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@6520a2d2cb6db42c90c297c8025839c98e531268
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+      - name: Login to DockerHub
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547
+        with:
+          context: ./.github/eosjs-ci
+          file: ./.github/eosjs-ci/Dockerfile
+          pull: true
+          push: true
+          tags: |
+            eosio/eosjs-ci:develop
+            eosio/eosjs-ci:${{ github.sha }}

--- a/.github/workflows/build-docker-develop.yml
+++ b/.github/workflows/build-docker-develop.yml
@@ -29,6 +29,7 @@ jobs:
           file: ./.github/eosjs-ci/Dockerfile
           pull: true
           push: true
+          no-cache: true
           tags: |
             eosio/eosjs-ci:develop
             eosio/eosjs-ci:${{ github.sha }}

--- a/.github/workflows/build-docker-release.yml
+++ b/.github/workflows/build-docker-release.yml
@@ -1,0 +1,37 @@
+name: Build Docker - Release
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  build-docker:
+    name: Build Docker - Release
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          ref: release/22.0.x
+          token: ${{ github.token }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@6520a2d2cb6db42c90c297c8025839c98e531268
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@154c24e1f33dbb5865a021c99f1318cfebf27b32
+      - name: Login to DockerHub
+        uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547
+        with:
+          context: ./.github/eosjs-ci
+          file: ./.github/eosjs-ci/Dockerfile
+          pull: true
+          push: true
+          build-args: |
+            EOSBRANCH=release_2.1.x
+            CDTBRANCH=release_1.8.x
+          tags: |
+            eosio/eosjs-ci:release_22.0.x
+            eosio/eosjs-ci:${{ github.sha }}

--- a/.github/workflows/build-docker-release.yml
+++ b/.github/workflows/build-docker-release.yml
@@ -29,6 +29,7 @@ jobs:
           file: ./.github/eosjs-ci/Dockerfile
           pull: true
           push: true
+          no-cache: true
           build-args: |
             EOSBRANCH=release_2.1.x
             CDTBRANCH=release_1.8.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           git push origin ${GITHUB_REF#refs/*/}
     services:
       nodeos:
-        image: eosio/eosjs-ci:v0.2.9
+        image: eosio/eosjs-ci:release_22.0.x
 
         ports:
           - 8888:8888

--- a/.github/workflows/integration-test-develop.yml
+++ b/.github/workflows/integration-test-develop.yml
@@ -1,12 +1,11 @@
-name: Publish Edge
+name: Integration Test - Develop
 on:
-  push:
-    branches:
-      - develop
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
-  publish-edge:
-    name: Publish Edge
+  integration-test:
+    name: Integration Test - Develop
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -14,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          ref: develop
+          token: ${{ github.token }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867
         with:
@@ -22,9 +24,6 @@ jobs:
       - name: Install
         run: |
           yarn --frozen-lockfile
-      - name: Lint
-        run: |
-          yarn lint
       - name: Test
         run: |
           yarn test
@@ -41,17 +40,6 @@ jobs:
         uses: cypress-io/github-action@6e9b583c9652e99b72b042a3957980fc6166efae
         with:
           spec: cypress/integration/index.spec.js
-      - name: Publish Edge
-        run: |
-          . ./scripts/publish-utils.sh
-          setup_git
-          COMMIT=${GITHUB_SHA:0:7}
-          sed -i "s/  \"version\": \"\([0-9]\+\).\([0-9]\+\).\([0-9]\+\)/&-$GITHUB_RUN_NUMBER-$COMMIT/" package.json
-          git commit -a -m "Updating version [skip ci]" --allow-empty
-          npm publish --access public --tag edge
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
     services:
       nodeos:
         image: eosio/eosjs-ci:develop

--- a/.github/workflows/integration-test-release.yml
+++ b/.github/workflows/integration-test-release.yml
@@ -1,12 +1,11 @@
-name: Publish Edge
+name: Integration Test - Release
 on:
-  push:
-    branches:
-      - develop
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
-  publish-edge:
-    name: Publish Edge
+  integration-test:
+    name: Integration Test - Release
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -14,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          ref: release/22.0.x
+          token: ${{ github.token }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867
         with:
@@ -22,9 +24,6 @@ jobs:
       - name: Install
         run: |
           yarn --frozen-lockfile
-      - name: Lint
-        run: |
-          yarn lint
       - name: Test
         run: |
           yarn test
@@ -41,20 +40,9 @@ jobs:
         uses: cypress-io/github-action@6e9b583c9652e99b72b042a3957980fc6166efae
         with:
           spec: cypress/integration/index.spec.js
-      - name: Publish Edge
-        run: |
-          . ./scripts/publish-utils.sh
-          setup_git
-          COMMIT=${GITHUB_SHA:0:7}
-          sed -i "s/  \"version\": \"\([0-9]\+\).\([0-9]\+\).\([0-9]\+\)/&-$GITHUB_RUN_NUMBER-$COMMIT/" package.json
-          git commit -a -m "Updating version [skip ci]" --allow-empty
-          npm publish --access public --tag edge
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
     services:
       nodeos:
-        image: eosio/eosjs-ci:develop
+        image: eosio/eosjs-ci:release_22.0.x
 
         ports:
           - 8888:8888

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,24 +8,17 @@ jobs:
     if: "!github.event.release.prerelease"
     name: Publish Release
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        node-version: [12.14.1]
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867
         with:
-          node-version: '12.14.1'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@70655ec8323daeeaa7ef06d7c56e1b9191396cbe
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install
         run: |
           yarn --frozen-lockfile
@@ -60,7 +53,7 @@ jobs:
 
     services:
       nodeos:
-        image: eosio/eosjs-ci:v0.2.9
+        image: eosio/eosjs-ci:release_22.0.x
 
         ports:
           - 8888:8888
@@ -71,24 +64,17 @@ jobs:
     if: "github.event.release.prerelease"
     name: Publish RC
     runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        node-version: [12.14.1]
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867
         with:
-          node-version: '12.14.1'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@70655ec8323daeeaa7ef06d7c56e1b9191396cbe
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install
         run: |
           yarn --frozen-lockfile
@@ -123,7 +109,7 @@ jobs:
 
     services:
       nodeos:
-        image: eosio/eosjs-ci:v0.2.9
+        image: eosio/eosjs-ci:release_22.0.x
 
         ports:
           - 8888:8888


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Adjusting the workflows to add two new pipelines to build and test with the release branches. Also changed the existing files to rename them to develop. Adjusted the dockerfile to take build arguments specifying which branches to use for eos and cdt. Lastly, changed the release stable, prerelease, and edge release workflows to have similar code.

_CI pipeline uses release_22.0.x docker tag for this branch specifically_

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
