### PR TITLE
Switching to eosio/eosio docker image in CI/CD (release/22.0.x)

### DIFF
--- a/.github/eosjs-ci/Dockerfile
+++ b/.github/eosjs-ci/Dockerfile
@@ -35,7 +35,7 @@ RUN cd cfhello \
  && eosio-cpp -abigen ./cfhello.cpp -o ./build/cfhello.wasm
 
 
-FROM eosio/eos:${EOSBRANCH}
+FROM eosio/eosio:${EOSBRANCH}
 ENTRYPOINT ["nodeos", "--data-dir", "/root/.local/share", "-e", "-p", "eosio", "--replay-blockchain", "--plugin", "eosio::producer_plugin", "--plugin", "eosio::chain_api_plugin", "--plugin", "eosio::trace_api_plugin", "--trace-no-abis", "--plugin", "eosio::db_size_api_plugin", "--plugin", "eosio::http_plugin", "--http-server-address=0.0.0.0:8888", "--access-control-allow-origin=*", "--contracts-console", "--http-validate-host=false", "--enable-account-queries=true", "--verbose-http-errors", "--max-transaction-time=100"]
 WORKDIR /root
 RUN mkdir -p "/opt/eosio/bin/contracts"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
eosio/eos image on docker is no longer updated which is causing the error in the integration tests. Switching to eosio/eosio will resolve the issue. 


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
