### PR TITLE
Removing NPM ecosystem from dependabot settings file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,30 +18,3 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "release/22.0.x"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "develop"
-    allowed_updates:
-      - match:
-          update_type: "security"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "release/21.0.x"
-    allowed_updates:
-      - match:
-          update_type: "security"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "release/22.0.x"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Unfortunately Github's built-in dependabot is missing two crucial features that would allow easier use: Grouping of PRs instead of separate PRs per dependency, and filtering updates to specific types.

Filtering updates was available in the old dependabot which still has documentation that unfortunately isn't correct for Github's built-in version.  This would be fine if it was also possible to group weekly dependency updates into one PR, but unfortunately without these two features, dependabot will open too many PRs too frequently.

The CI/CD workflow has a task that updates all dependencies, as long as commits/PRs are actively being created, this will suffice until dependabot gets more features.  Additionally, security updates will need to stay open against master (until a release solves the security issue) and cloned into develop and release branches.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
