### PR TITLE
Updating workflow nodejs versions to v16, replacing the matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Check for GIT_API_KEY
         id: check_token
@@ -28,10 +25,10 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Update
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,19 +8,16 @@ jobs:
   integration-test-release_21_0_x-release_2_0_x:
     name: Integration Test - eosjs release/21.0.x with nodeos release/2.0.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/21.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -48,19 +45,16 @@ jobs:
   integration-test-release_21_0_x-release_2_1_x:
     name: Integration Test - eosjs release/21.0.x with nodeos release/2.1.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/21.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -88,19 +82,16 @@ jobs:
   integration-test-release_21_0_x-develop:
     name: Integration Test - eosjs release/21.0.x with nodeos develop
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/21.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -128,19 +119,16 @@ jobs:
   integration-test-release_22_0_x-release_2_0_x:
     name: Integration Test - eosjs release/22.0.x with nodeos release/2.0.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/22.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -172,19 +160,16 @@ jobs:
   integration-test-release_22_0_x-release_2_1_x:
     name: Integration Test - eosjs release/22.0.x with nodeos release/2.1.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/22.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -215,19 +200,16 @@ jobs:
   integration-test-release_22_0_x-develop:
     name: Integration Test - eosjs release/22.0.x with nodeos develop
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: release/22.0.x
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -255,19 +237,16 @@ jobs:
   integration-test-develop-release_2_0_x:
     name: Integration Test - eosjs develop with nodeos release/2.0.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: develop
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -299,19 +278,16 @@ jobs:
   integration-test-develop-release_2_1_x:
     name: Integration Test - eosjs develop with nodeos release/2.1.x
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: develop
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -343,19 +319,16 @@ jobs:
   integration-test-develop-develop:
     name: Integration Test - eosjs develop with nodeos develop
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: develop
           token: ${{ github.token }}
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |

--- a/.github/workflows/publish-edge.yml
+++ b/.github/workflows/publish-edge.yml
@@ -8,16 +8,13 @@ jobs:
   publish-edge:
     name: Publish Edge
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,16 +8,13 @@ jobs:
     if: "!github.event.release.prerelease"
     name: Publish Release
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |
@@ -64,16 +61,13 @@ jobs:
     if: "github.event.release.prerelease"
     name: Publish RC
     runs-on: ubuntu-16.04
-    strategy:
-      matrix:
-        node-version: [15.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js v16.x.x
         uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: |


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Due to one of our sub-dependencies, it's advised to update our ci/cd workflow code to `"^12.20 || ^14.14.0 || ^16"`.  Since WebCrypto still requires v15/v16, we can move to v16.  Additionally, the nodejs github action has the ability to support the latest released version of nodejs for particular versions by specifying `'16'` as the node-version: https://github.com/actions/setup-node#supported-version-syntax

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
