### PR TITLE
Adjusting eosjs to use send_transaction or send_transaction_v2 depending on nodeos

### DIFF
--- a/docs/01_technical-overview.md
+++ b/docs/01_technical-overview.md
@@ -21,4 +21,4 @@ The typical use of the `Api` object is to call its [`transact` method](https://g
 * The entire transaction is then [serialized](https://github.com/EOSIO/eosjs/blob/master/src/eosjs-api.ts#L154-L166), also using the `eosjs-serialize` `ser` object.
 * The transaction is then optionally signed, using the `signatureProvider`, the previously retrieved `abi`s, the private keys of the `signatureProvider`, and the `chainId`.
 * The transaction is then optionally compressed, using the `deflate` function of a Javascript zlib library.
-* The transaction is then optionally broadcasted using `JsonRpc`'s [`push_transaction`](https://github.com/EOSIO/eosjs/blob/master/src/eosjs-jsonrpc.ts#L187).
+* The transaction is then optionally broadcasted using either `JsonRpc`'s [`send_transaction`](https://github.com/EOSIO/eosjs/blob/master/src/eosjs-jsonrpc.ts#L350) or[`send_transaction_v2`](https://github.com/EOSIO/eosjs/blob/master/src/eosjs-jsonrpc.ts#L362) depending on the nodeos version or [`send_ro_transaction`](https://github.com/EOSIO/eosjs/blob/master/src/eosjs-jsonrpc.ts#L324) if the transaction is read-only.

--- a/docs/how-to-guides/01_how-to-submit-a-transaction.md
+++ b/docs/how-to-guides/01_how-to-submit-a-transaction.md
@@ -137,4 +137,5 @@ From nodeos version 2.1, the ability to receive return values from smart contrac
 ### Read-Only Transactions
 From nodeos version 2.2, read-only queries have been introduced to eosjs. Adding `readOnlyTrx` to the `transact` config will send the transaction through the `send_ro_transaction` endpoint in the `chain_api`.  The `send_ro_transaction` endpoint does not allow the transaction to make any data changes despite the actions in the transaction. The `send_ro_transaction` endpoint may also be used to call normal actions, but any data changes that action will make will be rolled back.
 
-Adding returnFailureTraces to the transact config enables the return of a trace message if your transaction fails. At this time, this is only available for the `send_ro_transaction` endpoint.
+### Return Failure Traces
+From nodeos version 2.2, adding returnFailureTraces to the transact config enables the return of a trace message if your transaction fails. This is available for both send_ro_transaction and the v2 version of send_transaction.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.6",
     "typescript": "^4.4.3",
-    "webpack": "^5.53.0",
+    "webpack": "^5.54.0",
     "webpack-cli": "^4.8.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cypress/skip-test": "^2.6.1",
     "@types/elliptic": "^6.4.13",
     "@types/jest": "^26.0.24",
-    "@types/node": "^14.17.17",
+    "@types/node": "^14.17.18",
     "@types/node-fetch": "^2.5.12",
     "@types/pako": "^1.0.2",
     "atob": "^2.1.2",

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -397,8 +397,8 @@ export class Api {
             return this.sendSignedTransaction(
                 pushTransactionArgs,
                 returnFailureTraces,
-                compression,
                 readOnlyTrx,
+                compression,
             ) as Promise<TransactResult|ReadOnlyTransactResult>;
         }
         return pushTransactionArgs as PushTransactionArgs;
@@ -489,7 +489,7 @@ export class Api {
     ): Promise<TransactResult|ReadOnlyTransactResult> {
         const compressedSerializedTransaction = this.deflateSerializedArray(serializedTransaction);
         const compressedSerializedContextFreeData =
-                this.deflateSerializedArray(serializedContextFreeData || new Uint8Array(0));
+            this.deflateSerializedArray(serializedContextFreeData || new Uint8Array(0));
 
         if (readOnlyTrx) {
             return this.rpc.send_ro_transaction({
@@ -511,8 +511,8 @@ export class Api {
     public async sendSignedTransaction(
         { signatures, serializedTransaction, serializedContextFreeData }: PushTransactionArgs,
         returnFailureTraces = false,
-        compression = false,
         readOnlyTrx = false,
+        compression = false,
     ): Promise<TransactResult|ReadOnlyTransactResult> {
         if (compression) {
             serializedTransaction = this.deflateSerializedArray(serializedTransaction);

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -25,6 +25,7 @@ import {
     GetRawAbiResult,
     GetScheduledTransactionsResult,
     GetTableRowsResult,
+    GetSupportedApisResult,
     PushTransactionArgs,
     PackedTrx,
     ReadOnlyTransactResult,
@@ -302,6 +303,11 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
         })).required_keys);
     }
 
+    /** Get supported api endpoints for the node */
+    public async get_supported_apis(): Promise<GetSupportedApisResult> {
+        return await this.fetch('/v1/node/get_supported_apis', {});
+    }
+
     /** Push a serialized transaction (replaced by send_transaction, but returned format has changed) */
     public async push_transaction(
         { signatures, compression = 0, serializedTransaction, serializedContextFreeData }: PushTransactionArgs
@@ -349,6 +355,21 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
             compression,
             packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
             packed_trx: arrayToHex(serializedTransaction),
+        });
+    }
+
+    /** Send a serialized transaction through /v2/chain/send_transaction */
+    public async send_transaction_v2(
+        { signatures, compression = 0, serializedTransaction, serializedContextFreeData }: PushTransactionArgs,
+        returnFailureTraces: boolean = false): Promise<TransactResult> {
+        return await this.fetch('/v2/chain/send_transaction', {
+            transaction: {
+                signatures,
+                compression,
+                packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
+                packed_trx: arrayToHex(serializedTransaction),
+            },
+            return_failure_traces: returnFailureTraces,
         });
     }
 

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -492,6 +492,10 @@ export interface GetTableByScopeResult {
     more: string;
 }
 
+export interface GetSupportedApisResult {
+    apis: string[]
+}
+
 /** Arguments for `push_transaction` */
 export interface PushTransactionArgs {
     signatures: string[];

--- a/src/tests/eosjs-api.test.ts
+++ b/src/tests/eosjs-api.test.ts
@@ -498,7 +498,7 @@ describe('eosjs-api', () => {
                 textEncoder: new TextEncoder()
             });
 
-            const result = await api.sendSignedTransaction({ signatures: [], serializedTransaction: serializedTx}, true, false, true);
+            const result = await api.sendSignedTransaction({ signatures: [], serializedTransaction: serializedTx}, true, true);
             expect(result).toEqual('Success');
         });
     });

--- a/src/tests/eosjs-api.test.ts
+++ b/src/tests/eosjs-api.test.ts
@@ -133,7 +133,7 @@ const deserializedActions = [
 describe('eosjs-api', () => {
     let api: any;
     let rpc: any;
-    const fetch = async (input: any, init: any): Promise<any> => ({
+    let fetch = async (input: any, init: any): Promise<any> => ({
         ok: true,
         json: async () => {
             if (input === '/v1/chain/get_raw_abi') {
@@ -309,7 +309,9 @@ describe('eosjs-api', () => {
 
             expect(firstSerializedAction).toEqual(secondSerializedAction);
         });
+    });
 
+    describe('Transaction Extensions', () => {
         it('confirms the transaction extension serialization is reciprocal', async () => {
             const resourcePayerTrx = {
                 expiration: '2021-06-28T15:55:37.000',
@@ -409,6 +411,95 @@ describe('eosjs-api', () => {
             delete deserializedResourcePayerTrx.transaction_extensions;
 
             expect(deserializedResourcePayerTrx).toEqual(resourcePayerTrx);
+        });
+    });
+
+    describe('sendSignedTransaction', () => {
+        it('should use v1 send_transaction', async () => {
+            fetch = async (input: any, init: any): Promise<any> => ({
+                ok: true,
+                json: async () => {
+                    if (input === '/v1/chain/send_transaction') {
+                        return 'Success';
+                    }
+                    if (input === '/v1/node/get_supported_apis') {
+                        return { apis: ['/v1/chain/send_transaction'] };
+                    }
+
+                    return 'Failure';
+                },
+            });
+            rpc = new JsonRpc('', { fetch });
+            const signatureProvider = new JsSignatureProvider(['5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr']);
+            const chainId = '038f4b0fc8ff18a4f0842a8f0564611f6e96e8535901dd45e43ac8691a1c4dca';
+            api = new Api({
+                rpc,
+                signatureProvider,
+                chainId,
+                textDecoder: new TextDecoder(),
+                textEncoder: new TextEncoder()
+            });
+
+            const result = await api.sendSignedTransaction({ signatures: [], serializedTransaction: serializedTx});
+            expect(result).toEqual('Success');
+        });
+
+        it('should use v2 send_transaction', async () => {
+            fetch = async (input: any, init: any): Promise<any> => ({
+                ok: true,
+                json: async () => {
+                    if (input === '/v2/chain/send_transaction') {
+                        return 'Success';
+                    }
+                    if (input === '/v1/node/get_supported_apis') {
+                        return { apis: ['/v2/chain/send_transaction'] };
+                    }
+
+                    return 'Failure';
+                },
+            });
+            rpc = new JsonRpc('', { fetch });
+            const signatureProvider = new JsSignatureProvider(['5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr']);
+            const chainId = '038f4b0fc8ff18a4f0842a8f0564611f6e96e8535901dd45e43ac8691a1c4dca';
+            api = new Api({
+                rpc,
+                signatureProvider,
+                chainId,
+                textDecoder: new TextDecoder(),
+                textEncoder: new TextEncoder()
+            });
+
+            const result = await api.sendSignedTransaction({ signatures: [], serializedTransaction: serializedTx});
+            expect(result).toEqual('Success');
+        });
+
+        it('should use send_ro_transaction', async () => {
+            fetch = async (input: any, init: any): Promise<any> => ({
+                ok: true,
+                json: async () => {
+                    if (input === '/v1/chain/send_ro_transaction') {
+                        return 'Success';
+                    }
+                    if (input === '/v1/node/get_supported_apis') {
+                        return { apis: ['/v2/chain/send_transaction'] };
+                    }
+
+                    return 'Failure';
+                },
+            });
+            rpc = new JsonRpc('', { fetch });
+            const signatureProvider = new JsSignatureProvider(['5JtUScZK2XEp3g9gh7F8bwtPTRAkASmNrrftmx4AxDKD5K4zDnr']);
+            const chainId = '038f4b0fc8ff18a4f0842a8f0564611f6e96e8535901dd45e43ac8691a1c4dca';
+            api = new Api({
+                rpc,
+                signatureProvider,
+                chainId,
+                textDecoder: new TextDecoder(),
+                textEncoder: new TextEncoder()
+            });
+
+            const result = await api.sendSignedTransaction({ signatures: [], serializedTransaction: serializedTx}, true, false, true);
+            expect(result).toEqual('Success');
         });
     });
 });

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -374,7 +374,7 @@ const transactWithWebCrypto = async () => {
     });
 };
 
-const broadcastResult = async (signaturesAndPackedTransaction) => await api.pushSignedTransaction(signaturesAndPackedTransaction);
+const broadcastResult = async (signaturesAndPackedTransaction) => await api.sendSignedTransaction(signaturesAndPackedTransaction);
 
 const transactShouldFail = async () => await api.transact({
     actions: [{

--- a/src/tests/web.html
+++ b/src/tests/web.html
@@ -266,7 +266,7 @@
                 return false;
             };
         
-            const broadcastResult = async (signaturesAndPackedTransaction) => await api.pushSignedTransaction(signaturesAndPackedTransaction);
+            const broadcastResult = async (signaturesAndPackedTransaction) => await api.sendSignedTransaction(signaturesAndPackedTransaction);
         
             const testBroadcastResult = async (e) => {
                 resultsLabel = e.target;

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,14 +820,14 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.4.tgz#a12f0ee7847cf17a97f6fdf1093cb7a9af23cca4"
-  integrity sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA==
+  version "16.9.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
+  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
-"@types/node@^14.14.31", "@types/node@^14.17.17":
-  version "14.17.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.17.tgz#4ec7b71bbcb01a4e55455b60b18b1b6a783fe31d"
-  integrity sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==
+"@types/node@^14.14.31", "@types/node@^14.17.18":
+  version "14.17.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.18.tgz#0198489a751005f71217744aa966cd1f29447c81"
+  integrity sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1245,7 +1245,7 @@ ansi-regex@^4.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -1633,15 +1633,15 @@ browserify-sign@^4.0.0:
     safe-buffer "^5.2.0"
 
 browserslist@^4.14.5, browserslist@^4.16.6:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.0.tgz#1fcd81ec75b41d6d4994fb0831b92ac18c01649c"
-  integrity sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.1.tgz#a98d104f54af441290b7d592626dd541fa642eb9"
+  integrity sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==
   dependencies:
-    caniuse-lite "^1.0.30001254"
-    colorette "^1.3.0"
-    electron-to-chromium "^1.3.830"
+    caniuse-lite "^1.0.30001259"
+    electron-to-chromium "^1.3.846"
     escalade "^3.1.1"
-    node-releases "^1.1.75"
+    nanocolors "^0.1.5"
+    node-releases "^1.1.76"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -1744,10 +1744,12 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001254:
-  version "1.0.30001258"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz#b604eed80cc54a578e4bf5a02ae3ed49f869d252"
-  integrity sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==
+caniuse-lite@^1.0.30001259:
+  version "1.0.30001260"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz#e3be3f34ddad735ca4a2736fa9e768ef34316270"
+  integrity sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==
+  dependencies:
+    nanocolors "^0.1.0"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1924,7 +1926,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1, colorette@^1.3.0, colorette@^1.4.0:
+colorette@^1.2.1, colorette@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
@@ -2341,10 +2343,10 @@ ecurve@1.0.5:
   dependencies:
     bigi "^1.1.0"
 
-electron-to-chromium@^1.3.830:
-  version "1.3.845"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.845.tgz#326d3be3ee5d2c065f689119d441c997f9fd41d8"
-  integrity sha512-y0RorqmExFDI4RjLEC6j365bIT5UAXf9WIRcknvSFHVhbC/dRnCgJnPA3DUUW6SCC85QGKEafgqcHJ6uPdEP1Q==
+electron-to-chromium@^1.3.846:
+  version "1.3.849"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz#45a65a392565abc5b864624b9753393336426f4b"
+  integrity sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==
 
 elliptic@6.5.4, elliptic@^6.5.3:
   version "6.5.4"
@@ -3028,9 +3030,9 @@ glob-to-regexp@^0.4.1:
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -3542,9 +3544,9 @@ isstream@~0.1.2:
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.0.0-alpha.1:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
-  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz#e8900b3ed6069759229cf30f7067388d148aeb5e"
+  integrity sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==
 
 istanbul-lib-hook@^3.0.0:
   version "3.0.0"
@@ -4242,9 +4244,9 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 listr2@^3.8.3:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.12.1.tgz#75e515b86c66b60baf253542cc0dced6b60fedaf"
-  integrity sha512-oB1DlXlCzGPbvWhqYBZUQEPJKqsmebQWofXG6Mpbe3uIvoNl8mctBEojyF13ZyqwQ91clCWXpwsWp+t98K4FOQ==
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.12.2.tgz#2d55cc627111603ad4768a9e87c9c7bb9b49997e"
+  integrity sha512-64xC2CJ/As/xgVI3wbhlPWVPx0wfTqbUAkpb7bjDi0thSWMqrf07UFhrfsGoo8YSXmF049Rp9C0cjLC8rZxK9A==
   dependencies:
     cli-truncate "^2.1.0"
     colorette "^1.4.0"
@@ -4478,6 +4480,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanocolors@^0.1.0, nanocolors@^0.1.5:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
+  integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4544,7 +4551,7 @@ node-preload@^0.2.1:
   dependencies:
     process-on-spawn "^1.0.0"
 
-node-releases@^1.1.75:
+node-releases@^1.1.76:
   version "1.1.76"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.76.tgz#df245b062b0cafbd5282ab6792f7dccc2d97f36e"
   integrity sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==
@@ -5589,13 +5596,13 @@ string-length@^4.0.1:
     strip-ansi "^6.0.0"
 
 string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
-  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -5604,12 +5611,12 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    ansi-regex "^5.0.0"
+    ansi-regex "^5.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -5703,9 +5710,9 @@ terser-webpack-plugin@^5.1.3:
     terser "^5.7.2"
 
 terser@^5.7.2:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.8.0.tgz#c6d352f91aed85cc6171ccb5e84655b77521d947"
-  integrity sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.9.0.tgz#47d6e629a522963240f2b55fcaa3c99083d2c351"
+  integrity sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,7 +2378,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -2420,10 +2420,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-module-lexer@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
-  integrity sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==
+es-module-lexer@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.0.tgz#fe4c4621977bc668e285c5f1f70ca3b451095fda"
+  integrity sha512-qU2eN/XHsrl3E4y7mK1wdWnyy5c8gXtCbfP6Xcsemm7fPUR1PIV1JhZfP7ojcN0Fzp69CfrS3u76h2tusvfKiQ==
 
 es6-error@^4.0.1:
   version "4.1.1"
@@ -6096,10 +6096,10 @@ webpack-sources@^3.2.0:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
   integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
 
-webpack@^5.53.0:
-  version "5.53.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.53.0.tgz#f463cd9c6fc1356ae4b9b7ac911fd1f5b2df86af"
-  integrity sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==
+webpack@^5.54.0:
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.54.0.tgz#629f0cd14c7a4340af758a3c7cef25c50670ae4d"
+  integrity sha512-MAVKJMsIUotOQKzFOmN8ZkmMlj7BOyjDU6t1lomW9dWOme5WTStzGa3HMLdV1KYD1AiFETGsznL4LMSvj4tukw==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"
@@ -6110,8 +6110,8 @@ webpack@^5.53.0:
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.0"
-    es-module-lexer "^0.7.1"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,9 +2344,9 @@ ecurve@1.0.5:
     bigi "^1.1.0"
 
 electron-to-chromium@^1.3.846:
-  version "1.3.849"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.849.tgz#45a65a392565abc5b864624b9753393336426f4b"
-  integrity sha512-RweyW60HPOqIcxoKTGr38Yvtf2aliSUqX8dB3e9geJ0Bno0YLjcOX5F7/DPVloBkJWaPZ7xOM1A0Yme2T1A34w==
+  version "1.3.850"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.850.tgz#c56c72abfeab051b4b328beb894461c5912d0456"
+  integrity sha512-ZzkDcdzePeF4dhoGZQT77V2CyJOpwfTZEOg4h0x6R/jQhGt/rIRpbRyVreWLtD7B/WsVxo91URm2WxMKR9JQZA==
 
 elliptic@6.5.4, elliptic@^6.5.3:
   version "6.5.4"


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Now that return failure traces is available on /v2/chain/send_transaction and send_transaction is the more efficient method, api.transact now has a `sendSignedTransaction` method that directs the signed transaction dependent on whether it's read only and whether /v2/chain/send_transaction is available on the nodeos endpoint, otherwise it falls back to v1.

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
api.transact no longer uses push_transaction (breaking change)
api.sendSignedTransaction: method to send a signed transaction to either v1 send_transaction, v2 send_transaction or send_ro_transaction.


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Adjusted docs to reflect the change from push_transaction to any three endpoints depending on read-only or nodeos version.  Additionally added a section for return failure traces now that it is available for v2 send_transaction as well