### PR TITLE
Removing incompatible version runs of test-types

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -420,9 +420,6 @@ jobs:
         env:
           NODEOS_VER: 'develop'
           COVERAGE_TESTING: true
-      - name: Test Types
-        run: |
-          yarn test-types
       - name: Copy Coverage Files
         run: |
           mkdir -p ./coverage/multiple-sources
@@ -589,9 +586,6 @@ jobs:
         env:
           NODEOS_VER: 'release/2.2.x'
           COVERAGE_TESTING: true
-      - name: Test Types
-        run: |
-          yarn test-types
       - name: Copy Coverage Files
         run: |
           mkdir -p ./coverage/multiple-sources


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
develop of nodeos has changed some return types for trace api.  These new types have been added to develop but the ci/cd needs to change the nightly integration tests for versions that are no longer compatible, like release/22.1.x with develop, and develop with nodeos/2.2.x


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
