### PR TITLE
Removing coverage file for test types following previous work

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -425,7 +425,6 @@ jobs:
           mkdir -p ./coverage/multiple-sources
           cp ./coverage/test/coverage-final.json ./coverage/multiple-sources/test.json
           cp ./coverage/test-node/coverage-final.json ./coverage/multiple-sources/test-node.json
-          cp ./coverage/test-types/coverage-final.json ./coverage/multiple-sources/test-types.json
           ./node_modules/nyc/bin/nyc.js merge ./coverage/multiple-sources ./coverage/merged-output/coverage.json
           ./node_modules/nyc/bin/nyc.js report -t ./coverage/merged-output --report-dir ./coverage/merged-report --reporter=html
       - name: Build
@@ -591,7 +590,6 @@ jobs:
           mkdir -p ./coverage/multiple-sources
           cp ./coverage/test/coverage-final.json ./coverage/multiple-sources/test.json
           cp ./coverage/test-node/coverage-final.json ./coverage/multiple-sources/test-node.json
-          cp ./coverage/test-types/coverage-final.json ./coverage/multiple-sources/test-types.json
           ./node_modules/nyc/bin/nyc.js merge ./coverage/multiple-sources ./coverage/merged-output/coverage.json
           ./node_modules/nyc/bin/nyc.js report -t ./coverage/merged-output --report-dir ./coverage/merged-report --reporter=html
       - name: Build


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
We removed two runs of test-types when the nodeos version and eosjs version had changed for certain matchups.  Unfortunately did not remove the coverage file copy command as well so integration tests have been failing with "no file exists".


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
